### PR TITLE
Add web page API endpoints

### DIFF
--- a/src/WebDownloadr.Infrastructure/Data/Queries/ListWebPagesQueryService.cs
+++ b/src/WebDownloadr.Infrastructure/Data/Queries/ListWebPagesQueryService.cs
@@ -1,0 +1,17 @@
+using WebDownloadr.UseCases.WebPages;
+using WebDownloadr.UseCases.WebPages.List;
+using WebDownloadr.Infrastructure.Data;
+
+namespace WebDownloadr.Infrastructure.Data.Queries;
+
+public class ListWebPagesQueryService(AppDbContext db) : IListWebPagesQueryService
+{
+  public async Task<IEnumerable<WebPageDTO>> ListAsync()
+  {
+    var result = await db.Database.SqlQuery<WebPageDTO>(
+      $"SELECT Id, Url, Status FROM WebPages")
+      .ToListAsync();
+
+    return result;
+  }
+}

--- a/src/WebDownloadr.Infrastructure/InfrastructureServiceExtensions.cs
+++ b/src/WebDownloadr.Infrastructure/InfrastructureServiceExtensions.cs
@@ -4,6 +4,7 @@ using WebDownloadr.Infrastructure.Data;
 using WebDownloadr.Infrastructure.Data.Queries;
 using WebDownloadr.Infrastructure.Web;
 using WebDownloadr.UseCases.Contributors.List;
+using WebDownloadr.UseCases.WebPages.List;
 
 
 namespace WebDownloadr.Infrastructure;
@@ -22,6 +23,7 @@ public static class InfrastructureServiceExtensions
     services.AddScoped(typeof(IRepository<>), typeof(EfRepository<>))
       .AddScoped(typeof(IReadRepository<>), typeof(EfRepository<>))
       .AddScoped<IListContributorsQueryService, ListContributorsQueryService>()
+      .AddScoped<IListWebPagesQueryService, ListWebPagesQueryService>()
       .AddScoped<IDeleteContributorService, DeleteContributorService>()
       .AddScoped<IWebPageDownloader, SimpleWebPageDownloader>()
       .AddScoped<IDownloadWebPageService, DownloadWebPageService>();

--- a/src/WebDownloadr.UseCases/WebPages/Get/GetWebPageHandler.cs
+++ b/src/WebDownloadr.UseCases/WebPages/Get/GetWebPageHandler.cs
@@ -1,0 +1,15 @@
+using WebDownloadr.Core.WebPageAggregate;
+
+namespace WebDownloadr.UseCases.WebPages.Get;
+
+public class GetWebPageHandler(IReadRepository<WebPage> repository)
+  : IQueryHandler<GetWebPageQuery, Result<WebPageDTO>>
+{
+  public async Task<Result<WebPageDTO>> Handle(GetWebPageQuery request, CancellationToken cancellationToken)
+  {
+    var entity = await repository.GetByIdAsync(WebPageId.From(request.WebPageId), cancellationToken);
+    if (entity == null) return Result.NotFound();
+
+    return new WebPageDTO(entity.Id.Value, entity.Url.Value, entity.Status.Name);
+  }
+}

--- a/src/WebDownloadr.UseCases/WebPages/Get/GetWebPageQuery.cs
+++ b/src/WebDownloadr.UseCases/WebPages/Get/GetWebPageQuery.cs
@@ -1,0 +1,3 @@
+namespace WebDownloadr.UseCases.WebPages.Get;
+
+public record GetWebPageQuery(Guid WebPageId) : IQuery<Result<WebPageDTO>>;

--- a/src/WebDownloadr.UseCases/WebPages/List/IListWebPagesQueryService.cs
+++ b/src/WebDownloadr.UseCases/WebPages/List/IListWebPagesQueryService.cs
@@ -1,0 +1,6 @@
+namespace WebDownloadr.UseCases.WebPages.List;
+
+public interface IListWebPagesQueryService
+{
+  Task<IEnumerable<WebPageDTO>> ListAsync();
+}

--- a/src/WebDownloadr.UseCases/WebPages/List/ListWebPagesHandler.cs
+++ b/src/WebDownloadr.UseCases/WebPages/List/ListWebPagesHandler.cs
@@ -1,0 +1,11 @@
+namespace WebDownloadr.UseCases.WebPages.List;
+
+public class ListWebPagesHandler(IListWebPagesQueryService query)
+  : IQueryHandler<ListWebPagesQuery, Result<IEnumerable<WebPageDTO>>>
+{
+  public async Task<Result<IEnumerable<WebPageDTO>>> Handle(ListWebPagesQuery request, CancellationToken cancellationToken)
+  {
+    var result = await query.ListAsync();
+    return Result.Success(result);
+  }
+}

--- a/src/WebDownloadr.UseCases/WebPages/List/ListWebPagesQuery.cs
+++ b/src/WebDownloadr.UseCases/WebPages/List/ListWebPagesQuery.cs
@@ -1,0 +1,3 @@
+namespace WebDownloadr.UseCases.WebPages.List;
+
+public record ListWebPagesQuery(int? Skip, int? Take) : IQuery<Result<IEnumerable<WebPageDTO>>>;

--- a/src/WebDownloadr.Web/WebPages/CancelDownload.CancelDownloadRequest.cs
+++ b/src/WebDownloadr.Web/WebPages/CancelDownload.CancelDownloadRequest.cs
@@ -1,0 +1,9 @@
+namespace WebDownloadr.Web.WebPages;
+
+public class CancelDownloadRequest
+{
+  public const string Route = "/WebPages/{WebPageId:guid}/download/cancel";
+  public static string BuildRoute(Guid id) => Route.Replace("{WebPageId:guid}", id.ToString());
+
+  public Guid WebPageId { get; set; }
+}

--- a/src/WebDownloadr.Web/WebPages/CancelDownload.cs
+++ b/src/WebDownloadr.Web/WebPages/CancelDownload.cs
@@ -1,0 +1,26 @@
+using WebDownloadr.UseCases.WebPages.Download.CancelDownload;
+
+namespace WebDownloadr.Web.WebPages;
+
+public class CancelDownload(IMediator _mediator) : Endpoint<CancelDownloadRequest, Guid>
+{
+  public override void Configure()
+  {
+    Post(CancelDownloadRequest.Route);
+    AllowAnonymous();
+  }
+
+  public override async Task HandleAsync(CancelDownloadRequest request, CancellationToken cancellationToken)
+  {
+    var result = await _mediator.Send(new CancelDownloadCommand(request.WebPageId), cancellationToken);
+
+    if (result.IsSuccess)
+    {
+      Response = result.Value;
+    }
+    else if (result.Status == ResultStatus.NotFound)
+    {
+      await SendNotFoundAsync(cancellationToken);
+    }
+  }
+}

--- a/src/WebDownloadr.Web/WebPages/Create.cs
+++ b/src/WebDownloadr.Web/WebPages/Create.cs
@@ -1,6 +1,24 @@
-﻿namespace WebDownloadr.Web.WebPages;
+using WebDownloadr.Core.WebPageAggregate;
+using WebDownloadr.UseCases.WebPages.Create;
 
-public class Create() 
+namespace WebDownloadr.Web.WebPages;
+
+public class Create(IMediator _mediator)
+  : Endpoint<CreateWebPageRequest, CreateWebPageResponse>
 {
-  
+  public override void Configure()
+  {
+    Post(CreateWebPageRequest.Route);
+    AllowAnonymous();
+  }
+
+  public override async Task HandleAsync(CreateWebPageRequest request, CancellationToken cancellationToken)
+  {
+    var result = await _mediator.Send(new CreateWebPageCommand(WebPageUrl.From(request.Url!)), cancellationToken);
+
+    if (result.IsSuccess)
+    {
+      Response = new CreateWebPageResponse(result.Value.Value, request.Url!);
+    }
+  }
 }

--- a/src/WebDownloadr.Web/WebPages/Delete.DeleteWebPageRequest.cs
+++ b/src/WebDownloadr.Web/WebPages/Delete.DeleteWebPageRequest.cs
@@ -1,0 +1,9 @@
+namespace WebDownloadr.Web.WebPages;
+
+public record DeleteWebPageRequest
+{
+  public const string Route = "/WebPages/{Id:guid}";
+  public static string BuildRoute(Guid id) => Route.Replace("{Id:guid}", id.ToString());
+
+  public Guid Id { get; set; }
+}

--- a/src/WebDownloadr.Web/WebPages/Delete.DeleteWebPageValidator.cs
+++ b/src/WebDownloadr.Web/WebPages/Delete.DeleteWebPageValidator.cs
@@ -1,0 +1,12 @@
+using FastEndpoints;
+using FluentValidation;
+
+namespace WebDownloadr.Web.WebPages;
+
+public class DeleteWebPageValidator : Validator<DeleteWebPageRequest>
+{
+  public DeleteWebPageValidator()
+  {
+    RuleFor(x => x.Id).NotEmpty();
+  }
+}

--- a/src/WebDownloadr.Web/WebPages/Delete.cs
+++ b/src/WebDownloadr.Web/WebPages/Delete.cs
@@ -1,0 +1,30 @@
+using WebDownloadr.UseCases.WebPages.Delete;
+
+namespace WebDownloadr.Web.WebPages;
+
+public class Delete(IMediator _mediator) : Endpoint<DeleteWebPageRequest>
+{
+  public override void Configure()
+  {
+    Delete(DeleteWebPageRequest.Route);
+    AllowAnonymous();
+  }
+
+  public override async Task HandleAsync(DeleteWebPageRequest request, CancellationToken cancellationToken)
+  {
+    var command = new DeleteWebPageCommand(request.Id);
+
+    var result = await _mediator.Send(command, cancellationToken);
+
+    if (result.Status == ResultStatus.NotFound)
+    {
+      await SendNotFoundAsync(cancellationToken);
+      return;
+    }
+
+    if (result.IsSuccess)
+    {
+      await SendNoContentAsync(cancellationToken);
+    }
+  }
+}

--- a/src/WebDownloadr.Web/WebPages/Download.DownloadWebPageRequest.cs
+++ b/src/WebDownloadr.Web/WebPages/Download.DownloadWebPageRequest.cs
@@ -1,0 +1,9 @@
+namespace WebDownloadr.Web.WebPages;
+
+public class DownloadWebPageRequest
+{
+  public const string Route = "/WebPages/{WebPageId:guid}/download";
+  public static string BuildRoute(Guid webPageId) => Route.Replace("{WebPageId:guid}", webPageId.ToString());
+
+  public Guid WebPageId { get; set; }
+}

--- a/src/WebDownloadr.Web/WebPages/Download.cs
+++ b/src/WebDownloadr.Web/WebPages/Download.cs
@@ -1,0 +1,26 @@
+using WebDownloadr.UseCases.WebPages.Download.DownloadWebPage;
+
+namespace WebDownloadr.Web.WebPages;
+
+public class Download(IMediator _mediator) : Endpoint<DownloadWebPageRequest, Guid>
+{
+  public override void Configure()
+  {
+    Post(DownloadWebPageRequest.Route);
+    AllowAnonymous();
+  }
+
+  public override async Task HandleAsync(DownloadWebPageRequest request, CancellationToken cancellationToken)
+  {
+    var result = await _mediator.Send(new DownloadWebPageCommand(request.WebPageId), cancellationToken);
+
+    if (result.IsSuccess)
+    {
+      Response = result.Value;
+    }
+    else if (result.Status == ResultStatus.NotFound)
+    {
+      await SendNotFoundAsync(cancellationToken);
+    }
+  }
+}

--- a/src/WebDownloadr.Web/WebPages/DownloadBatch.DownloadWebPagesRequest.cs
+++ b/src/WebDownloadr.Web/WebPages/DownloadBatch.DownloadWebPagesRequest.cs
@@ -1,0 +1,11 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace WebDownloadr.Web.WebPages;
+
+public class DownloadWebPagesRequest
+{
+  public const string Route = "/WebPages/download";
+
+  [Required]
+  public IEnumerable<Guid> Ids { get; set; } = [];
+}

--- a/src/WebDownloadr.Web/WebPages/DownloadBatch.cs
+++ b/src/WebDownloadr.Web/WebPages/DownloadBatch.cs
@@ -1,0 +1,20 @@
+using WebDownloadr.UseCases.WebPages.Download.DownloadWebPages;
+
+namespace WebDownloadr.Web.WebPages;
+
+public class DownloadBatch(IMediator _mediator) : Endpoint<DownloadWebPagesRequest, IEnumerable<Guid>>
+{
+  public override void Configure()
+  {
+    Post(DownloadWebPagesRequest.Route);
+    AllowAnonymous();
+  }
+
+  public override async Task HandleAsync(DownloadWebPagesRequest request, CancellationToken cancellationToken)
+  {
+    var result = await _mediator.Send(new DownloadWebPagesCommand(request.Ids), cancellationToken);
+
+    var successful = result.Where(r => r.IsSuccess).Select(r => r.Value);
+    Response = successful.ToList();
+  }
+}

--- a/src/WebDownloadr.Web/WebPages/GetById.GetWebPageByIdRequest.cs
+++ b/src/WebDownloadr.Web/WebPages/GetById.GetWebPageByIdRequest.cs
@@ -1,0 +1,9 @@
+namespace WebDownloadr.Web.WebPages;
+
+public class GetWebPageByIdRequest
+{
+  public const string Route = "/WebPages/{WebPageId:guid}";
+  public static string BuildRoute(Guid webPageId) => Route.Replace("{WebPageId:guid}", webPageId.ToString());
+
+  public Guid WebPageId { get; set; }
+}

--- a/src/WebDownloadr.Web/WebPages/GetById.GetWebPageValidator.cs
+++ b/src/WebDownloadr.Web/WebPages/GetById.GetWebPageValidator.cs
@@ -1,0 +1,13 @@
+using FastEndpoints;
+using FluentValidation;
+
+namespace WebDownloadr.Web.WebPages;
+
+public class GetWebPageValidator : Validator<GetWebPageByIdRequest>
+{
+  public GetWebPageValidator()
+  {
+    RuleFor(x => x.WebPageId)
+      .NotEmpty();
+  }
+}

--- a/src/WebDownloadr.Web/WebPages/GetById.cs
+++ b/src/WebDownloadr.Web/WebPages/GetById.cs
@@ -1,0 +1,31 @@
+using WebDownloadr.UseCases.WebPages.Get;
+using WebDownloadr.Core.WebPageAggregate;
+
+namespace WebDownloadr.Web.WebPages;
+
+public class GetById(IMediator _mediator) : Endpoint<GetWebPageByIdRequest, WebPageRecord>
+{
+  public override void Configure()
+  {
+    Get(GetWebPageByIdRequest.Route);
+    AllowAnonymous();
+  }
+
+  public override async Task HandleAsync(GetWebPageByIdRequest request, CancellationToken cancellationToken)
+  {
+    var query = new GetWebPageQuery(request.WebPageId);
+    var result = await _mediator.Send(query, cancellationToken);
+
+    if (result.Status == ResultStatus.NotFound)
+    {
+      await SendNotFoundAsync(cancellationToken);
+      return;
+    }
+
+    if (result.IsSuccess)
+    {
+      var dto = result.Value;
+      Response = new WebPageRecord(dto.Id, dto.Url, DownloadStatus.FromName(dto.Status));
+    }
+  }
+}

--- a/src/WebDownloadr.Web/WebPages/List.WebPageListResponse.cs
+++ b/src/WebDownloadr.Web/WebPages/List.WebPageListResponse.cs
@@ -1,0 +1,6 @@
+namespace WebDownloadr.Web.WebPages;
+
+public class WebPageListResponse
+{
+  public List<WebPageRecord> WebPages { get; set; } = [];
+}

--- a/src/WebDownloadr.Web/WebPages/List.cs
+++ b/src/WebDownloadr.Web/WebPages/List.cs
@@ -1,0 +1,27 @@
+using WebDownloadr.UseCases.WebPages;
+using WebDownloadr.UseCases.WebPages.List;
+using WebDownloadr.Core.WebPageAggregate;
+
+namespace WebDownloadr.Web.WebPages;
+
+public class List(IMediator _mediator) : EndpointWithoutRequest<WebPageListResponse>
+{
+  public override void Configure()
+  {
+    Get("/WebPages");
+    AllowAnonymous();
+  }
+
+  public override async Task HandleAsync(CancellationToken cancellationToken)
+  {
+    var result = await _mediator.Send(new ListWebPagesQuery(null, null), cancellationToken);
+
+    if (result.IsSuccess)
+    {
+      Response = new WebPageListResponse
+      {
+        WebPages = result.Value.Select(p => new WebPageRecord(p.Id, p.Url, DownloadStatus.FromName(p.Status))).ToList()
+      };
+    }
+  }
+}

--- a/src/WebDownloadr.Web/WebPages/RetryDownload.RetryDownloadRequest.cs
+++ b/src/WebDownloadr.Web/WebPages/RetryDownload.RetryDownloadRequest.cs
@@ -1,0 +1,9 @@
+namespace WebDownloadr.Web.WebPages;
+
+public class RetryDownloadRequest
+{
+  public const string Route = "/WebPages/{WebPageId:guid}/download/retry";
+  public static string BuildRoute(Guid id) => Route.Replace("{WebPageId:guid}", id.ToString());
+
+  public Guid WebPageId { get; set; }
+}

--- a/src/WebDownloadr.Web/WebPages/RetryDownload.cs
+++ b/src/WebDownloadr.Web/WebPages/RetryDownload.cs
@@ -1,0 +1,26 @@
+using WebDownloadr.UseCases.WebPages.Download.RetryDownload;
+
+namespace WebDownloadr.Web.WebPages;
+
+public class RetryDownload(IMediator _mediator) : Endpoint<RetryDownloadRequest, Guid>
+{
+  public override void Configure()
+  {
+    Post(RetryDownloadRequest.Route);
+    AllowAnonymous();
+  }
+
+  public override async Task HandleAsync(RetryDownloadRequest request, CancellationToken cancellationToken)
+  {
+    var result = await _mediator.Send(new RetryDownloadCommand(request.WebPageId), cancellationToken);
+
+    if (result.IsSuccess)
+    {
+      Response = result.Value;
+    }
+    else if (result.Status == ResultStatus.NotFound)
+    {
+      await SendNotFoundAsync(cancellationToken);
+    }
+  }
+}

--- a/src/WebDownloadr.Web/WebPages/Update.UpdateWebPageRequest.cs
+++ b/src/WebDownloadr.Web/WebPages/Update.UpdateWebPageRequest.cs
@@ -1,0 +1,17 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace WebDownloadr.Web.WebPages;
+
+public class UpdateWebPageRequest
+{
+  public const string Route = "/WebPages/{WebPageId:guid}";
+  public static string BuildRoute(Guid webPageId) => Route.Replace("{WebPageId:guid}", webPageId.ToString());
+
+  public Guid WebPageId { get; set; }
+
+  [Required]
+  public Guid Id { get; set; }
+
+  [Required]
+  public string? Status { get; set; }
+}

--- a/src/WebDownloadr.Web/WebPages/Update.UpdateWebPageResponse.cs
+++ b/src/WebDownloadr.Web/WebPages/Update.UpdateWebPageResponse.cs
@@ -1,0 +1,6 @@
+namespace WebDownloadr.Web.WebPages;
+
+public class UpdateWebPageResponse(WebPageRecord webPage)
+{
+  public WebPageRecord WebPage { get; set; } = webPage;
+}

--- a/src/WebDownloadr.Web/WebPages/Update.UpdateWebPageValidator.cs
+++ b/src/WebDownloadr.Web/WebPages/Update.UpdateWebPageValidator.cs
@@ -1,0 +1,17 @@
+using FastEndpoints;
+using FluentValidation;
+
+namespace WebDownloadr.Web.WebPages;
+
+public class UpdateWebPageValidator : Validator<UpdateWebPageRequest>
+{
+  public UpdateWebPageValidator()
+  {
+    RuleFor(x => x.Status)
+      .NotEmpty();
+
+    RuleFor(x => x.WebPageId)
+      .Must((req, id) => req.Id == id)
+      .WithMessage("Route and body Ids must match; cannot update Id of an existing resource.");
+  }
+}

--- a/src/WebDownloadr.Web/WebPages/Update.cs
+++ b/src/WebDownloadr.Web/WebPages/Update.cs
@@ -1,0 +1,32 @@
+using WebDownloadr.UseCases.WebPages.Get;
+using WebDownloadr.UseCases.WebPages.Update;
+using WebDownloadr.Core.WebPageAggregate;
+
+namespace WebDownloadr.Web.WebPages;
+
+public class Update(IMediator _mediator) : Endpoint<UpdateWebPageRequest, UpdateWebPageResponse>
+{
+  public override void Configure()
+  {
+    Put(UpdateWebPageRequest.Route);
+    AllowAnonymous();
+  }
+
+  public override async Task HandleAsync(UpdateWebPageRequest request, CancellationToken cancellationToken)
+  {
+    var result = await _mediator.Send(new UpdateWebPageCommand(WebPageId.From(request.Id), DownloadStatus.FromName(request.Status!)), cancellationToken);
+
+    if (result.Status == ResultStatus.NotFound)
+    {
+      await SendNotFoundAsync(cancellationToken);
+      return;
+    }
+
+    if (result.IsSuccess)
+    {
+      var dto = result.Value;
+      Response = new UpdateWebPageResponse(new WebPageRecord(dto.Id, dto.Url, DownloadStatus.FromName(dto.Status)));
+      return;
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- implement web page endpoints (create, list, get, update, delete, download actions)
- create corresponding request/response models and validators
- add query handlers for getting and listing web pages
- support list queries in infrastructure services
- fix naming for download request models

## Testing
- `dotnet build WebDownloadr.sln`
- `dotnet test tests/WebDownloadr.UnitTests/WebDownloadr.UnitTests.csproj --no-build -v minimal`
- `dotnet test tests/WebDownloadr.FunctionalTests/WebDownloadr.FunctionalTests.csproj --no-build -v minimal`
- `dotnet test tests/WebDownloadr.IntegrationTests/WebDownloadr.IntegrationTests.csproj --no-build -v minimal`


------
https://chatgpt.com/codex/tasks/task_e_686bd8116840832d9739ee991630107e