### PR TITLE
Add URI validation for web page URLs

### DIFF
--- a/src/WebDownloadr.Web/WebPages/Create.CreateWebPageValidator.cs
+++ b/src/WebDownloadr.Web/WebPages/Create.CreateWebPageValidator.cs
@@ -8,8 +8,17 @@ public class CreateWebPageValidator : Validator<CreateWebPageRequest>
   {
     RuleFor(x => x.Url)
       .NotEmpty()
-      .WithMessage("Url is required");
-    
-    // TODO: Proper URI validation
+      .WithMessage("Url is required")
+      .Must(BeAValidHttpUrl)
+      .WithMessage("Url must be a valid HTTP or HTTPS address");
+  }
+
+  private static bool BeAValidHttpUrl(string? url)
+  {
+    if (string.IsNullOrWhiteSpace(url))
+      return false;
+
+    return Uri.TryCreate(url, UriKind.Absolute, out var uri)
+      && (uri.Scheme == Uri.UriSchemeHttp || uri.Scheme == Uri.UriSchemeHttps);
   }
 }

--- a/tests/WebDownloadr.UnitTests/Web/WebPages/CreateWebPageValidator_Validate.cs
+++ b/tests/WebDownloadr.UnitTests/Web/WebPages/CreateWebPageValidator_Validate.cs
@@ -1,0 +1,29 @@
+using WebDownloadr.Web.WebPages;
+
+namespace WebDownloadr.UnitTests.Web.WebPages;
+
+public class CreateWebPageValidator_Validate
+{
+  private readonly CreateWebPageValidator _validator = new();
+
+  [Fact]
+  public void ReturnsValidGivenHttpUrl()
+  {
+    var request = new CreateWebPageRequest { Url = "https://example.com" };
+
+    var result = _validator.Validate(request);
+
+    result.IsValid.ShouldBeTrue();
+  }
+
+  [Fact]
+  public void ReturnsInvalidGivenBadUrl()
+  {
+    var request = new CreateWebPageRequest { Url = "ftp://example.com" };
+
+    var result = _validator.Validate(request);
+
+    result.IsValid.ShouldBeFalse();
+    result.Errors.ShouldContain(e => e.ErrorMessage == "Url must be a valid HTTP or HTTPS address");
+  }
+}

--- a/tests/WebDownloadr.UnitTests/WebDownloadr.UnitTests.csproj
+++ b/tests/WebDownloadr.UnitTests/WebDownloadr.UnitTests.csproj
@@ -39,6 +39,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\WebDownloadr.Core\WebDownloadr.Core.csproj" />
     <ProjectReference Include="..\..\src\WebDownloadr.UseCases\WebDownloadr.UseCases.csproj" />
+    <ProjectReference Include="..\..\src\WebDownloadr.Web\WebDownloadr.Web.csproj" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary
- validate URLs using `Uri.TryCreate` in `CreateWebPageValidator`
- test valid and invalid URLs
- reference web project in unit tests

## Testing
- `dotnet test WebDownloadr.sln`

------
https://chatgpt.com/codex/tasks/task_e_686c95f3481c832da0dedb33c1e7b2ef