### PR TITLE
Add web page download tests

### DIFF
--- a/tests/WebDownloadr.FunctionalTests/ApiEndpoints/WebPageCreateList.cs
+++ b/tests/WebDownloadr.FunctionalTests/ApiEndpoints/WebPageCreateList.cs
@@ -1,0 +1,22 @@
+using Ardalis.HttpClientTestExtensions;
+using Shouldly;
+using WebDownloadr.Web.WebPages;
+
+namespace WebDownloadr.FunctionalTests.ApiEndpoints;
+
+[Collection("Sequential")]
+public class WebPageCreateList(CustomWebApplicationFactory<Program> factory) : IClassFixture<CustomWebApplicationFactory<Program>>
+{
+    private readonly HttpClient _client = factory.CreateClient();
+
+    [Fact]
+    public async Task CanCreateWebPage()
+    {
+        var request = new CreateWebPageRequest { Url = "https://example.com" };
+        var create = await _client.PostAndDeserializeAsync<CreateWebPageResponse>(CreateWebPageRequest.Route, StringContentHelpers.FromModelAsJson(request));
+
+        create.Url.ShouldBe("https://example.com");
+
+        // verify create succeeded by returning same url
+    }
+}

--- a/tests/WebDownloadr.IntegrationTests/Data/BaseEfRepoWebPageFixture.cs
+++ b/tests/WebDownloadr.IntegrationTests/Data/BaseEfRepoWebPageFixture.cs
@@ -1,0 +1,37 @@
+using NSubstitute;
+using Ardalis.SharedKernel;
+using Microsoft.EntityFrameworkCore;
+using WebDownloadr.Core.WebPageAggregate;
+using WebDownloadr.Infrastructure.Data;
+
+namespace WebDownloadr.IntegrationTests.Data;
+
+public abstract class BaseEfRepoWebPageFixture
+{
+    protected AppDbContext _dbContext;
+
+    protected BaseEfRepoWebPageFixture()
+    {
+        var options = CreateNewContextOptions();
+        var dispatcher = Substitute.For<IDomainEventDispatcher>();
+        _dbContext = new AppDbContext(options, dispatcher);
+    }
+
+    protected static DbContextOptions<AppDbContext> CreateNewContextOptions()
+    {
+        var serviceProvider = new ServiceCollection()
+            .AddEntityFrameworkInMemoryDatabase()
+            .BuildServiceProvider();
+
+        var builder = new DbContextOptionsBuilder<AppDbContext>();
+        builder.UseInMemoryDatabase("cleanarchitecture")
+               .UseInternalServiceProvider(serviceProvider);
+
+        return builder.Options;
+    }
+
+    protected EfRepository<WebPage> GetRepository()
+    {
+        return new EfRepository<WebPage>(_dbContext);
+    }
+}

--- a/tests/WebDownloadr.IntegrationTests/Data/WebPages/EfRepositoryWebPageAdd.cs
+++ b/tests/WebDownloadr.IntegrationTests/Data/WebPages/EfRepositoryWebPageAdd.cs
@@ -1,0 +1,24 @@
+using Shouldly;
+using WebDownloadr.Core.WebPageAggregate;
+using System.Linq;
+using System;
+
+namespace WebDownloadr.IntegrationTests.Data.WebPages;
+
+public class EfRepositoryWebPageAdd : BaseEfRepoWebPageFixture
+{
+    [Fact]
+    public async Task AddsWebPageAndSetsId()
+    {
+        var repository = GetRepository();
+        var page = new WebPage(WebPageUrl.From("https://example.com"));
+
+        await repository.AddAsync(page);
+
+        var result = (await repository.ListAsync()).FirstOrDefault();
+        result.ShouldNotBeNull();
+        result.Url.ShouldBe(page.Url);
+        result.Status.ShouldBe(page.Status);
+        result.Id.Value.ShouldNotBe(Guid.Empty);
+    }
+}

--- a/tests/WebDownloadr.IntegrationTests/Data/WebPages/EfRepositoryWebPageDelete.cs
+++ b/tests/WebDownloadr.IntegrationTests/Data/WebPages/EfRepositoryWebPageDelete.cs
@@ -1,0 +1,20 @@
+using Shouldly;
+using WebDownloadr.Core.WebPageAggregate;
+
+using System.Linq;
+namespace WebDownloadr.IntegrationTests.Data.WebPages;
+
+public class EfRepositoryWebPageDelete : BaseEfRepoWebPageFixture
+{
+    [Fact]
+    public async Task DeletesWebPageAfterAdding()
+    {
+        var repository = GetRepository();
+        var page = new WebPage(WebPageUrl.From("https://todelete.com"));
+        await repository.AddAsync(page);
+
+        await repository.DeleteAsync(page);
+
+        (await repository.ListAsync()).ShouldNotContain(p => p.Url.Value == "https://todelete.com");
+    }
+}

--- a/tests/WebDownloadr.IntegrationTests/Data/WebPages/EfRepositoryWebPageUpdate.cs
+++ b/tests/WebDownloadr.IntegrationTests/Data/WebPages/EfRepositoryWebPageUpdate.cs
@@ -1,0 +1,26 @@
+using Shouldly;
+using Microsoft.EntityFrameworkCore;
+using WebDownloadr.Core.WebPageAggregate;
+using System.Linq;
+
+namespace WebDownloadr.IntegrationTests.Data.WebPages;
+
+public class EfRepositoryWebPageUpdate : BaseEfRepoWebPageFixture
+{
+    [Fact]
+    public async Task UpdatesWebPageAfterAdding()
+    {
+        var repository = GetRepository();
+        var page = new WebPage(WebPageUrl.From("https://initial.com"));
+        await repository.AddAsync(page);
+        _dbContext.Entry(page).State = EntityState.Detached;
+
+        var fetched = (await repository.ListAsync()).First(p => p.Url.Value == "https://initial.com");
+        fetched.UpdateStatus(DownloadStatus.DownloadCompleted);
+
+        await repository.UpdateAsync(fetched);
+
+        var updated = (await repository.ListAsync()).First(p => p.Id == fetched.Id);
+        updated.Status.ShouldBe(DownloadStatus.DownloadCompleted);
+    }
+}

--- a/tests/WebDownloadr.UnitTests/Core/Services/DownloadWebPageService_DownloadWebPageAsync.cs
+++ b/tests/WebDownloadr.UnitTests/Core/Services/DownloadWebPageService_DownloadWebPageAsync.cs
@@ -1,0 +1,126 @@
+using Ardalis.Result;
+using NSubstitute;
+using Shouldly;
+using System.Collections.Concurrent;
+using System.Reflection;
+using WebDownloadr.Core.Interfaces;
+using System.Linq;
+using System.IO;
+using WebDownloadr.Core.Services;
+using WebDownloadr.Core.WebPageAggregate;
+using WebDownloadr.Core.WebPageAggregate.Events;
+
+namespace WebDownloadr.UnitTests.Core.Services;
+
+public class DownloadWebPageService_DownloadWebPageAsync
+{
+    private readonly IRepository<WebPage> _repository = Substitute.For<IRepository<WebPage>>();
+    private readonly IMediator _mediator = Substitute.For<IMediator>();
+
+    [Fact]
+    public async Task UpdatesStatusAndPublishesEventOnSuccess()
+    {
+        var downloader = new FakeDownloader(true);
+        var service = new DownloadWebPageService(_repository, downloader, _mediator);
+        var page = new WebPage(WebPageUrl.From("https://example.com")) { Id = WebPageId.From(Guid.NewGuid()) };
+        _repository.GetByIdAsync<Guid>(page.Id.Value, Arg.Any<CancellationToken>()).Returns(page);
+        _repository.UpdateAsync(page, Arg.Any<CancellationToken>()).Returns(Task.FromResult(1));
+
+        ClearActiveDownloads();
+        try
+        {
+            var result = await service.DownloadWebPageAsync(page.Id.Value, CancellationToken.None);
+
+            result.IsSuccess.ShouldBeTrue();
+            page.Status.ShouldBe(DownloadStatus.DownloadCompleted);
+            var calls = _mediator.ReceivedCalls().ToList();
+            calls.ShouldContain(c => c.GetMethodInfo().Name == "Publish");
+            var published = calls.First(c => c.GetMethodInfo().Name == "Publish").GetArguments()[0]!;
+            published.GetType().Name.ShouldBe("WebPageDownloadedEvent");
+            var idProperty = published.GetType().GetProperty("Id")!;
+            var idProp = (Guid)idProperty.GetValue(published)!;
+            idProp.ShouldBe(page.Id.Value);
+            var contentProperty = published.GetType().GetProperty("Content")!;
+            var contentProp = (string)contentProperty.GetValue(published)!;
+            contentProp.ShouldBe(FakeDownloader.Content);
+            IsDownloadActive(page.Id.Value).ShouldBeFalse();
+        }
+        finally
+        {
+            Cleanup();
+        }
+    }
+
+    [Fact]
+    public async Task SetsErrorStatusOnFailure()
+    {
+        var downloader = new FakeDownloader(false);
+        var service = new DownloadWebPageService(_repository, downloader, _mediator);
+        var page = new WebPage(WebPageUrl.From("https://example.com")) { Id = WebPageId.From(Guid.NewGuid()) };
+        _repository.GetByIdAsync<Guid>(page.Id.Value, Arg.Any<CancellationToken>()).Returns(page);
+        _repository.UpdateAsync(page, Arg.Any<CancellationToken>()).Returns(Task.FromResult(1));
+
+        ClearActiveDownloads();
+        try
+        {
+            var result = await service.DownloadWebPageAsync(page.Id.Value, CancellationToken.None);
+
+            result.IsSuccess.ShouldBeFalse();
+            page.Status.ShouldBe(DownloadStatus.DownloadError);
+            _mediator.ReceivedCalls().ShouldNotContain(c => c.GetMethodInfo().Name == "Publish");
+            IsDownloadActive(page.Id.Value).ShouldBeFalse();
+        }
+        finally
+        {
+            Cleanup();
+        }
+    }
+
+    private static bool IsDownloadActive(Guid id)
+    {
+        var dict = GetActiveDownloads();
+        return dict.ContainsKey(id);
+    }
+
+    private static void ClearActiveDownloads()
+    {
+        GetActiveDownloads().Clear();
+    }
+
+    private static ConcurrentDictionary<Guid, CancellationTokenSource> GetActiveDownloads()
+    {
+        var field = typeof(DownloadWebPageService).GetField("_activeDownloads", BindingFlags.Static | BindingFlags.NonPublic)!;
+        return (ConcurrentDictionary<Guid, CancellationTokenSource>)field.GetValue(null)!;
+    }
+
+    private static void Cleanup()
+    {
+        if (Directory.Exists("downloads"))
+            Directory.Delete("downloads", true);
+    }
+
+    private class FakeDownloader(bool succeed) : IWebPageDownloader
+    {
+        public const string Content = "<html>content</html>";
+        private readonly bool _succeed = succeed;
+
+        public Task<Result> DownloadWebPagesAsync(IEnumerable<string> urls, string outputDir, CancellationToken cancellationToken)
+        {
+            Directory.CreateDirectory(outputDir);
+            var url = urls.First();
+            var fileName = Path.Combine(outputDir, GetSafeFilename(url) + ".html");
+            File.WriteAllText(fileName, Content);
+            return Task.FromResult(_succeed ? Result.Success() : Result.Error("fail"));
+        }
+
+        private static string GetSafeFilename(string url)
+        {
+            foreach (var c in Path.GetInvalidFileNameChars())
+            {
+                url = url.Replace(c, '_');
+            }
+
+            return url.Replace("https://", "").Replace("http://", "").Replace("/", "_");
+        }
+    }
+}

--- a/tests/WebDownloadr.UnitTests/Core/WebPageAggregate/WebPageUrl_From.cs
+++ b/tests/WebDownloadr.UnitTests/Core/WebPageAggregate/WebPageUrl_From.cs
@@ -7,4 +7,18 @@ public class WebPageUrl_From
   {
     Should.Throw<ValueObjectValidationException>(() => WebPageUrl.From("foo"));
   }
+
+  [Fact]
+  public void CreatesGivenValidHttpUrl()
+  {
+    var url = WebPageUrl.From("http://example.com");
+    url.Value.ShouldBe("http://example.com");
+  }
+
+  [Fact]
+  public void CreatesGivenValidHttpsUrl()
+  {
+    var url = WebPageUrl.From("https://example.com");
+    url.Value.ShouldBe("https://example.com");
+  }
 }

--- a/tests/WebDownloadr.UnitTests/UseCases/WebPages/Download/DownloadHandlers_Delegates.cs
+++ b/tests/WebDownloadr.UnitTests/UseCases/WebPages/Download/DownloadHandlers_Delegates.cs
@@ -1,0 +1,67 @@
+using Ardalis.Result;
+using NSubstitute;
+using Shouldly;
+using WebDownloadr.Core.Interfaces;
+using WebDownloadr.UseCases.WebPages.Download.CancelDownload;
+using WebDownloadr.UseCases.WebPages.Download.DownloadWebPage;
+using WebDownloadr.UseCases.WebPages.Download.DownloadWebPages;
+using WebDownloadr.UseCases.WebPages.Download.RetryDownload;
+
+namespace WebDownloadr.UnitTests.UseCases.WebPages.Download;
+
+public class DownloadHandlers_Delegates
+{
+    private readonly IDownloadWebPageService _service = Substitute.For<IDownloadWebPageService>();
+
+    [Fact]
+    public async Task CancelDownloadHandler_DelegatesToService()
+    {
+        var handler = new CancelDownloadHandler(_service);
+        var id = Guid.NewGuid();
+        _service.CancelDownloadAsync(id, Arg.Any<CancellationToken>()).Returns(Result.Success(id));
+
+        var result = await handler.Handle(new CancelDownloadCommand(id), CancellationToken.None);
+
+        result.IsSuccess.ShouldBeTrue();
+        await _service.Received().CancelDownloadAsync(id, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task DownloadWebPageHandler_DelegatesToService()
+    {
+        var handler = new DownloadWebPageHandler(_service);
+        var id = Guid.NewGuid();
+        _service.DownloadWebPageAsync(id, Arg.Any<CancellationToken>()).Returns(Result.Success(id));
+
+        var result = await handler.Handle(new DownloadWebPageCommand(id), CancellationToken.None);
+
+        result.IsSuccess.ShouldBeTrue();
+        await _service.Received().DownloadWebPageAsync(id, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task DownloadWebPagesHandler_DelegatesToService()
+    {
+        var handler = new DownloadWebPagesHandler(_service);
+        var ids = new[] { Guid.NewGuid(), Guid.NewGuid() };
+        _service.DownloadWebPagesAsync(ids, Arg.Any<CancellationToken>()).Returns(new[] { Result.Success(ids[0]), Result.Success(ids[1]) });
+
+        var result = await handler.Handle(new DownloadWebPagesCommand(ids), CancellationToken.None);
+
+        result.Count().ShouldBe(2);
+        await _service.Received().DownloadWebPagesAsync(ids, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task RetryDownloadHandler_DelegatesToService()
+    {
+        var handler = new RetryDownloadHandler(_service);
+        var id = Guid.NewGuid();
+        _service.RetryDownloadAsync(id, Arg.Any<CancellationToken>()).Returns(Result.Success(id));
+
+        var result = await handler.Handle(new RetryDownloadCommand(id), CancellationToken.None);
+
+        result.IsSuccess.ShouldBeTrue();
+        await _service.Received().RetryDownloadAsync(id, Arg.Any<CancellationToken>());
+    }
+}


### PR DESCRIPTION
## Summary
- add comprehensive service tests for downloading
- test download command handlers delegate to service
- cover repository operations for `WebPage`
- validate URL value objects
- add functional test for web page creation

## Testing
- `dotnet test tests/WebDownloadr.UnitTests/WebDownloadr.UnitTests.csproj -v minimal`
- `dotnet test tests/WebDownloadr.IntegrationTests/WebDownloadr.IntegrationTests.csproj -v minimal`
- `dotnet test tests/WebDownloadr.FunctionalTests/WebDownloadr.FunctionalTests.csproj -v minimal`


------
https://chatgpt.com/codex/tasks/task_e_686ca9dcd954832dae6fecd84f46eee7