### PR TITLE
[Docs] docs: mention gitattributes for line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+# Normalize line endings
+* text=auto eol=crlf
+
+# Shell scripts should remain LF
+*.sh text eol=lf

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -173,16 +173,17 @@ Run this script locally **before pushing a branch or opening a PR**. Any non‑z
    - charset = utf-8-bom
    - trim_trailing_whitespace = true
    - insert_final_newline = true
+   - `.gitattributes` enforces CRLF for most files while shell scripts (`*.sh`) use LF
 
 2. **CI Enforcement**
    Formatting is enforced via `dotnet format --verify-no-changes`.
    Run `./scripts/format.sh` or `dotnet format` locally before committing.
    Set `git config --global core.autocrlf true` to avoid line-ending mismatches.
-   A one-time normalization may be required:
+   A one-time normalization may be required when `.gitattributes` is introduced or changed:
 
    ```bash
    git add --renormalize .
-   git commit -m "style: normalize line endings to match .editorconfig"
+   git commit -m "style: normalize line endings to match .editorconfig and .gitattributes"
    ```
 
 Formatting violations will block PRs.

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Additional documentation lives in the `docs` folder and within each project. Sta
 
 ## Formatting
 
-Formatting is enforced in CI. Configure Git to honor `.editorconfig` line endings:
+Formatting is enforced in CI. Line endings are normalized via `.gitattributes` — CRLF for most files while `*.sh` scripts use LF. Configure Git to honor `.editorconfig` line endings:
 
 ```bash
 git config --global core.autocrlf true


### PR DESCRIPTION
## Summary
- add a `.gitattributes` file to manage line endings
- document line ending enforcement in README and AGENTS

## Testing
- `./scripts/selfcheck.sh` *(fails: `reportgenerator: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_686da2cd135c832d966fdc3cf5437641