### PR TITLE
[ServiceDefaults] add Codex env setup script

### DIFF
--- a/scripts/setup-codex.sh
+++ b/scripts/setup-codex.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+./scripts/setup-dotnet.sh
+./scripts/install-tools.sh
+
+echo "✅ Codex environment ready."


### PR DESCRIPTION
## Summary
- add a helper script `setup-codex.sh` for Codex environments
- mark it executable

## Testing
- `dotnet restore WebDownloadr.sln`
- `./scripts/selfcheck.sh`

------
https://chatgpt.com/codex/tasks/task_e_686e0cb63378832d81ed900e506e8401