### PR TITLE
[Build] fix: source dotnet path in codex setup

### DIFF
--- a/scripts/setup-codex.sh
+++ b/scripts/setup-codex.sh
@@ -3,7 +3,8 @@ set -euo pipefail
 
 cd "$(dirname "$0")/.."
 
-./scripts/setup-dotnet.sh
+# Source setup-dotnet so PATH updates propagate
+source ./scripts/setup-dotnet.sh
 ./scripts/install-tools.sh
 
 echo "✅ Codex environment ready."


### PR DESCRIPTION
## Summary
- ensure `setup-codex.sh` sources the dotnet installer so PATH updates are available for tool installation

## Testing
- `dotnet restore WebDownloadr.sln`
- `./scripts/selfcheck.sh`

------
https://chatgpt.com/codex/tasks/task_e_686e10e73fcc832daa7b4adedef59a1b