### PR TITLE
Add output schema guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -392,6 +392,38 @@ All ADR files reside under `docs/architecture-decisions/` and follow the [ardali
 - [.NET 9 SDK – What’s New](https://learn.microsoft.com/aspnet/core/release-notes/aspnetcore-9.0?view=aspnetcore-9.0)
 
 ---
+## Output Schemas
+
+Agent generated responses may be consumed by other tools and therefore must
+adhere to strict JSON or YAML schemas. Every defined property is required and no
+additional fields are permitted.
+
+### Example
+
+```json
+{
+  "status": "success",
+  "tests": {
+    "total": 42,
+    "passed": 42,
+    "failed": 0
+  }
+}
+```
+
+The `status` value communicates success or failure while the `tests` object
+captures overall results. Use the same structure when emitting YAML:
+
+```yaml
+status: success
+tests:
+  total: 42
+  passed: 42
+  failed: 0
+```
+
+Responses **must match these schemas exactly**—omit any extraneous properties.
+
 
 ## Guidance for AI Agents
 


### PR DESCRIPTION
## Summary
- add an **Output Schemas** section before the AI guidance in `AGENTS.md`

## Testing
- `dotnet restore WebDownloadr.sln`
- `./scripts/selfcheck.sh`

------
https://chatgpt.com/codex/tasks/task_e_686e31e31a24832dbce1e72fa8cac943