### PR TITLE
[Docs] add fallbacks and escalation guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -287,3 +287,13 @@ They reside under `docs/architecture-decisions/` and mirror the
 * If unsure, prefer **not to change** a file unless a clear rule or test requires it.
 * If multiple valid approaches exist, prefer the **simplest and most idiomatic** .NET solution.
 * Always output **minimal diffs**—avoid broad formatting or style changes outside the scope of your PR.
+
+## Fallbacks and Escalation
+
+Agents must halt and request clarification whenever a repository rule or instruction is unclear or appears conflicting.
+
+* **Stop** – If you cannot interpret a domain rule or architectural guideline with confidence, pause implementation.
+* **Ask** – Seek guidance from project maintainers via a comment or PR description when uncertain about next steps.
+* **Defer** – If a decision risks violating the codebase's principles, escalate to human review before proceeding.
+
+Err on the side of caution and avoid speculative changes. Explicit confirmation from maintainers resolves any ambiguity.


### PR DESCRIPTION
## Summary
- specify when agents should halt, ask, or defer for help in `AGENTS.md`

## Testing
- `./scripts/selfcheck.sh` *(fails: Assets file not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e44cff7a8832d9860ad7fd69aa3de