### PR TITLE
[Docs] clarify testing relaxations

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -730,6 +730,17 @@ Run this script locally **before pushing a branch or opening a PR**. Any non-zer
 - **Coverage validation** – Run `dotnet test --collect:"XPlat Code Coverage"` for all test projects and invoke `reportgenerator -reporttypes:HtmlSummary` on the results. Line coverage must remain **>= 90%**.
 - **Agent-generated tests** – When an AI agent adds or modifies tests, verify they compile and pass. Include the resulting `HtmlSummary` report (or a screenshot) in the PR description to demonstrate coverage.
 
+- **Analyzer relaxations for test code**
+
+  - The test projects suppress **StyleCop rule CA1707** (identifiers should not contain underscores) so that test method names can use a descriptive pattern such as  
+    `MethodUnderTest_ShouldReturnExpectedResult_WhenCondition`.  
+  - Additional StyleCop or Roslyn rules may be disabled in test assemblies **only** when they improve test readability and do **not** affect production code.
+
+- **Snapshot-test exception to minimal-diff rule**
+
+  - Files under `tests/**/Snapshots/` (e.g., approval or snapshot assets) are treated as *generated artifacts*; the **“always output minimal diffs”** rule is waived for these files.  
+    When a functional change legitimately updates a snapshot, commit the full new file—even if it is large—to preserve the canonical expected output.
+
 ---
 
 ## Pull‑Request Guidelines

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -11,4 +11,6 @@
   <PropertyGroup>
     <NoWarn>1591</NoWarn> <!-- Remove this to turn on warnings for missing XML Comments -->
   </PropertyGroup>
-</Project>
+  <PropertyGroup Condition="'$(IsTestProject)' == 'true'">
+    <NoWarn>$(NoWarn);CA1707</NoWarn>
+  </PropertyGroup></Project>


### PR DESCRIPTION
## Summary
- detail allowed analyzer relaxations for test projects
- note snapshot file exception to minimal-diff rule
- configure Directory.Build.props to silence CA1707 for test projects

## Testing
- `./scripts/selfcheck.sh`

------
https://chatgpt.com/codex/tasks/task_e_686e7ef4cf30832db1d69cf80546d6a3