### PR TITLE
Fix AGENTS doc sections

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,33 +1,38 @@
 ---
 title: AGENTS
 project: WebDownloadr
-language: "C# 12 (.NET 9)"
-architecture: "Clean Architecture (Ardalis Template)"
+language: C# 12 (.NET 9)
+architecture: Clean Architecture (Ardalis Template)
 layers:
-  Core: "Domain: Entities, ValueObjects, Events, Interfaces (Ardalis.GuardClauses & Ardalis.Specification only)"
-  UseCases: "Application: CQRS handlers, DTOs, validators (depends only on Core)"
-  Infrastructure: "Persistence: EF Core context, external service adapters (depends on Core)"
-  Web: "API: FastEndpoints HTTP host (depends on UseCases, Infrastructure, ServiceDefaults)"
-  ServiceDefaults: "Cross-cutting: startup & telemetry for .NET Aspire / cloud"
-  AspireHost: "Hosting: .NET Aspire entry point (preview in .NET 9)"
-  Tests: "Unit, Integration, Functional, Aspire tests (mirror src structure)"
-dependency_flow: "References flow inward. Core → none; UseCases → Core; Infrastructure → Core; Web → UseCases (+ Infrastructure only in Program/Startup for DI)."
+  Core: >-
+    Domain: Entities, ValueObjects, Events, Interfaces (Ardalis.GuardClauses &
+    Ardalis.Specification only)
+  UseCases: 'Application: CQRS handlers, DTOs, validators (depends only on Core)'
+  Infrastructure: 'Persistence: EF Core context, external service adapters (depends on Core)'
+  Web: >-
+    API: FastEndpoints HTTP host (depends on UseCases, Infrastructure,
+    ServiceDefaults)
+  ServiceDefaults: 'Cross-cutting: startup & telemetry for .NET Aspire / cloud'
+  AspireHost: 'Hosting: .NET Aspire entry point (preview in .NET 9)'
+  Tests: 'Unit, Integration, Functional, Aspire tests (mirror src structure)'
+dependency_flow: >-
+  References flow inward. Core → none; UseCases → Core; Infrastructure → Core;
+  Web → UseCases (+ Infrastructure only in Program/Startup for DI).
 ci_requirements:
   build_warnings: 0
-  tests_pass: "100%"
-  coverage_min: "≥ 90%"
+  tests_pass: 100%
+  coverage_min: ≥ 90%
   formatting_drift: 0
-commit_convention: "Conventional Commits (<type>(<scope>): <summary>)"
+commit_convention: 'Conventional Commits (<type>(<scope>): <summary>)'
 branch_prefixes:
   - feature/
   - fix/
   - chore/
   - docs/
-agents_md_inheritance: "Global (~/.codex) → Repo root → Nested (deeper overrides parent)"
-date_created: 2025-07-09T09:41:12+02:00
-date_modified: 2025-07-09T13:50:00+02:00
+agents_md_inheritance: Global (~/.codex) → Repo root → Nested (deeper overrides parent)
+date_created: 2025-07-09T07:41:12.000Z
+date_modified: 2025-07-09T11:50:00.000Z
 ---
-
 # AGENTS.md
 > **This file is a Binding for AI agents (e.g., [OpenAI Codex](https://platform.openai.com/docs/overview)) _and_ human contributors.**  
 > Any contribution must comply with every rule herein, or the pull‑request will be rejected.  
@@ -44,7 +49,6 @@ date_modified: 2025-07-09T13:50:00+02:00
 - [DO NOT](#do-not)
 - [Quality Gates](#quality-gates)
 - [Output Schemas](#output-schemas)
-- [Prompt Engineering for AI Agents](#prompt-engineering-for-ai-agents)
 - [Runtime Environment](#runtime-environment)
 - [Allowed Tools & APIs](#allowed-tools--apis)
 - [Database & Migrations](#database--migrations)
@@ -516,13 +520,13 @@ Existing history need not be rewritten; simply adopt the new format from this po
 |--------------------------|-------------------------------------------------------------------------------------------------|
 | Build warnings           | **0** (none)                                                                                    |
 | Unit & integration tests | **100%** pass                                                                                   |
-| Line coverage            | **≥ 90%** (via [Coverlet](https://github.com/coverlet-coverage/coverlet)) (not implemented yet) |
+| Line coverage            | **≥ 90%** (via [Coverlet](https://github.com/coverlet-coverage/coverlet)) |
 | Formatter drift          | **0** files (`dotnet format --verify-no-changes`)                                               |
 | Architecture tests | **pass** (`./scripts/archtest.sh`) |
 
 The wrapper executes WebDownloadr.ArchTests (ArchUnitNET) and fails CI if any forbidden dependency is detected.
 
--### Architecture Enforcement (CI)
+### Architecture Enforcement (CI)
 - The `WebDownloadr.ArchTests` project verifies layer rules using **ArchUnitNET**.
 - CI step `./scripts/archtest.sh` must pass.
 - Rules:
@@ -636,7 +640,7 @@ If the agent generates multiple new files (scaffolding, ADR drafts), list them i
 
 ---
 
-## Prompt Engineering for AI Agents
+## Prompt Engineering for Agents
 
 > These rules help AI contributors deliver high-quality, low-friction output.
 > Humans may ignore—AI **must** comply.
@@ -683,6 +687,26 @@ If no answer after two attempts ⇒ **escalate to human reviewer**.
 * ❌ Skipping self-check
 
 > Agents deviating from this guidance will have their PR auto-closed by CI.
+
+### Step-by-Step Reasoning
+1. Read the request and identify the target layer or file.
+2. Outline the minimal steps needed to implement the change.
+3. Execute each step, validating results along the way.
+4. Ensure updates respect Clean Architecture boundaries.
+5. Summarize the outcome in the PR description.
+
+### Clarifying Questions
+When tasks are ambiguous, consider asking:
+- "Which project or layer should this affect?"
+- "What scenario or user story drives the change?"
+- "Are existing tests available to guide the update?"
+
+### Workflow Checklist
+- [ ] Run `./scripts/selfcheck.sh` and confirm all checks pass.
+- [ ] Verify no secrets or credentials were introduced.
+- [ ] Format code via `dotnet format --verify-no-changes`.
+- [ ] Add or update tests for new behavior.
+- [ ] Commit using `<type>(<scope>): <summary>`.
 
 ---
 
@@ -778,6 +802,8 @@ dotnet restore WebDownloadr.sln
 dotnet build --no-restore -warnaserror
 
 dotnet test --no-build --no-restore WebDownloadr.sln --collect:"XPlat Code Coverage" --results-directory ./TestResults
+
+./scripts/archtest.sh
 
 dotnet format --verify-no-changes WebDownloadr.sln --no-restore
 
@@ -1179,49 +1205,8 @@ _Only update an ADR’s **Status** or add a supersession notice—**do not** rew
 
 - Always output **minimal diffs** so commits stay focused and avoid unrelated changes. Widen your changes only to fix formatting errors or analyzer warnings, or if the instructions explicitly request a broader update.
 
-### State & Context Awareness
-
-AI agents often complete **multi-step tasks** (e.g., draft an ADR → implement code → update tests). To avoid drifting context or leaking data, follow these rules:
-
-1. **Carry identifiers forward.**
-   If your first step creates a *UseCase* named `DownloadPageCommand`, reference that exact name (or ADR ID, issue number, etc.) in all subsequent steps and commit messages.
-
-2. **Short-lived in-memory context only.**
-   Persist information **only** in the branch you’re working on (code, ADRs, tests). Do **not** write to external stores, long-term caches, or hidden files.
-
-3. **No secret retention.**
-   Environment variables, API keys, or user-secrets may be read during the run but **must never** be logged, committed, or stored in agent memory between runs.
-
-4. **Re-load on each invocation.**
-   Assume the agent starts “fresh” every time. Re-read modified files (e.g., the ADR you just wrote) before generating follow-up changes rather than relying on previous prompt history.
-
-5. **Ask if context is unclear.**
-   If the required identifier (ADR ID, entity name, etc.) is missing or ambiguous, **pause and request clarification** instead of guessing.
-
-These guidelines keep multi-step contributions consistent, reproducible, and free of accidental data leaks.
-
 ---
 
-## Prompt Engineering for Agents
-
-Use a structured process when generating changes.
-
-### Step-by-Step Reasoning
-1. Read the request and identify the target layer or file.
-2. Outline the minimal steps needed to implement the change.
-3. Execute each step, validating results along the way.
-4. Ensure updates respect Clean Architecture boundaries.
-5. Summarize the outcome in the PR description.
-
-### Clarifying Questions
-When tasks are ambiguous, consider asking:
-- "Which project or layer should this affect?"
-- "What scenario or user story drives the change?"
-- "Are existing tests available to guide the update?"
-
-### Workflow Checklist
-- [ ] Run `./scripts/selfcheck.sh` and confirm all checks pass.
-- [ ] Verify no secrets or credentials were introduced.
 - [ ] Format code via `dotnet format --verify-no-changes`.
 - [ ] Add or update tests for new behavior.
 - [ ] Commit using `<type>(<scope>): <summary>`.
@@ -1251,13 +1236,6 @@ This file is a *living contract*.
 
 The owner is responsible for scheduling reviews, merging routine fixes, and flagging stale guidance.
 
-## Performance & Safety Controls
-
-- **Default to safe limits.** When mocking external services is unavailable, restrict outbound API calls to the bare minimum, ideally none.
-- **Monitor resource usage.** If tasks require excessive CPU, memory, or I/O, reduce workload or halt execution.
-- **Escalate when uncertain.** When limits are exceeded or instructions remain ambiguous, pause work and request human guidance before proceeding.
-
----
 
 ## Fallbacks & Escalation
 


### PR DESCRIPTION
## Summary
- merge the two Prompt Engineering sections
- remove redundant Performance & Safety Controls section
- prune duplicate state-awareness guidance
- update the build script snippet to include architecture tests
- regenerate ToC and drop outdated coverage note

## Testing
- `./scripts/selfcheck.sh` *(fails: project assets missing)*

------
https://chatgpt.com/codex/tasks/task_e_686e94f14e4c832da38d38767c56784f