### PR TITLE
Add Prettier dev dependency

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -867,7 +867,11 @@ will be auto-closed by CI.
      git commit -m "style: normalize line endings to match .editorconfig"
      ```
 
-   - Formatting violations will block PRs (treat warnings from analyzers as errors).
+  - Formatting violations will block PRs (treat warnings from analyzers as errors).
+
+3. **Docs** – Lint Markdown with `markdownlint-cli2` and format with Prettier.
+   - Run `npx markdownlint-cli2` to check all `.md` files.
+   - Run `npx prettier --check .` before committing to ensure consistent formatting.
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,8 @@
   "packages": {
     "": {
       "devDependencies": {
-        "markdownlint-cli2": "^0.18.1"
+        "markdownlint-cli2": "^0.18.1",
+        "prettier": "^3.6.2"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -1131,6 +1132,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.6.2.tgz",
+      "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/punycode.js": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "devDependencies": {
-    "markdownlint-cli2": "^0.18.1"
+    "markdownlint-cli2": "^0.18.1",
+    "prettier": "^3.6.2"
   }
 }


### PR DESCRIPTION
## Summary
- include Prettier in devDependencies
- document Prettier and markdownlint usage

## Testing
- `./scripts/selfcheck.sh`

------
https://chatgpt.com/codex/tasks/task_e_686eeac00ba8832db045a05a45810fe5