### PR TITLE
docs: mention markdownlint and Prettier

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,7 +79,7 @@ while following modern .NET 9 best practices.
 
 ## Nested **AGENTS.md** Inheritance & Layer-Specific Overrides
 
-> **Precedence** (lowest → highest): **Global** `~/.codex/AGENTS.md` → **Repo root** `/<repo>/AGENTS.md` → **Nested**
+> **Precedence** (lowest → highest): **Global** `~/.codex/AGENTS.md` → **Repo root** `/<repo>/AGENTS.md` → **Nested** >
 > `/<repo>/<folder>/AGENTS.md` A nested file automatically **inherits** every rule from its parent. If the nested file restates a rule,
 > **the nested version wins** for that folder and its descendants.
 
@@ -792,6 +792,7 @@ dotnet ef database update -c AppDbContext \
 ## Validation & Invariants
 
 - **Input validation** occurs in two layers:
+
   1. **Web endpoints** – validate incoming requests via FluentValidation or FastEndpoints’ built‑in validators.
 
   2. **UseCases handlers** – re-validate commands/queries via pipeline behaviors (to guard against bypassing Web validation).
@@ -844,6 +845,7 @@ will be auto-closed by CI.
 ## Code Formatting
 
 1. **`.editorconfig` is canonical** – the project enforces specific formatting settings:
+
    - `indent_style = space`
 
    - `*.{cs,csx,vb,vbx}` → **2-space indentation**
@@ -860,6 +862,7 @@ will be auto-closed by CI.
 
 2. **CI Enforcement** – Formatting is enforced via `dotnet format --verify-no-changes`. Run `./scripts/format.sh` or `dotnet format` locally
    before committing. Also set `git config --global core.autocrlf true` to avoid line-ending issues.
+
    - A one-time line-ending normalization may be required if inconsistencies exist:
 
      ```bash
@@ -868,6 +871,9 @@ will be auto-closed by CI.
      ```
 
    - Formatting violations will block PRs (treat warnings from analyzers as errors).
+
+3. **Documentation linting** – Run `npx markdownlint-cli2 "**/*.md"` and `npx prettier --check .` to keep Markdown and JSON files formatted
+   consistently. Rules are defined in `.markdownlint.json` and `.prettierrc`.
 
 ---
 
@@ -1043,6 +1049,7 @@ public sealed class EfRepository<T> : IRepository<T>
   report (or a screenshot) in the PR description to demonstrate coverage.
 
 - **Analyzer relaxations for test code**
+
   - The test projects suppress **StyleCop rule CA1707** (identifiers should not contain underscores) so that test method names can use a
     descriptive pattern such as  
     `MethodUnderTest_ShouldReturnExpectedResult_WhenCondition`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,8 +5,9 @@ Thank you for helping improve **WebDownloadr**. This repository follows the work
 ## Quick Start
 
 1. Run `./scripts/setup-codex.sh` to install the .NET SDK and required global tools.
-2. Execute `./scripts/selfcheck.sh` and make sure it exits with `0`.
-3. Commit using the format `[Layer] <type>: <summary>` following [Conventional Commits](https://www.conventionalcommits.org/).
+2. Run `npx prettier --check .` and `npx markdownlint-cli2` to verify documentation formatting (see `AGENTS.md`).
+3. Execute `./scripts/selfcheck.sh` and make sure it exits with `0`.
+4. Commit using the format `[Layer] <type>: <summary>` following [Conventional Commits](https://www.conventionalcommits.org/).
 
 ## Pull Requests
 
@@ -14,5 +15,5 @@ Submit pull requests against the `main` branch. All checks in `selfcheck.sh` mus
 
 ## Code Style & Testing
 
-Formatting, analyzers, and test coverage are enforced via `dotnet format` and `dotnet test` with Coverlet. See `AGENTS.md` for detailed guidance.
-
+Formatting, analyzers, and test coverage are enforced via `dotnet format` and `dotnet test` with Coverlet. See `AGENTS.md` for detailed
+guidance.

--- a/README.md
+++ b/README.md
@@ -1,12 +1,15 @@
 # WebDownloadr
+
 ![CI](https://github.com/beriniwlew/webdownloadr/actions/workflows/ci.yml/badge.svg?branch=main)
 
-WebDownloadr demonstrates how to apply Clean Architecture to a simple web page downloader built with .NET 9. The solution is organized into separate projects that isolate the domain model, application services, infrastructure and API.
+WebDownloadr demonstrates how to apply Clean Architecture to a simple web page downloader built with .NET 9. The solution is organized into
+separate projects that isolate the domain model, application services, infrastructure and API.
 
 ## Projects
 
 - **WebDownloadr.Core** – domain model containing the [`WebPage` aggregate](src/WebDownloadr.Core/WebPageAggregate/README.md).
-- **WebDownloadr.UseCases** – application layer describing operations such as requesting downloads (see [README](src/WebDownloadr.UseCases/README.md)).
+- **WebDownloadr.UseCases** – application layer describing operations such as requesting downloads (see
+  [README](src/WebDownloadr.UseCases/README.md)).
 - **WebDownloadr.Infrastructure** – implementations of external dependencies like HTTP clients.
 - **WebDownloadr.Web** – minimal API exposing endpoints (see [README](src/WebDownloadr.Web/README.md)).
 - **Tests** – unit, integration and functional test projects.
@@ -23,12 +26,12 @@ Browse to `/swagger` for API documentation while the app is running.
 
 ## Environment Setup
 
-Run `./scripts/setup-codex.sh` to install the .NET SDK and required global
-tools before building the solution.
+Run `./scripts/setup-codex.sh` to install the .NET SDK and required global tools before building the solution.
 
 ## Documentation
 
-Additional documentation lives in the `docs` folder and within each project. Start with [`src/WebDownloadr.Core/README.md`](src/WebDownloadr.Core/README.md) to learn about the domain model.
+Additional documentation lives in the `docs` folder and within each project. Start with
+[`src/WebDownloadr.Core/README.md`](src/WebDownloadr.Core/README.md) to learn about the domain model.
 
 ## Formatting
 
@@ -48,7 +51,8 @@ git commit -m "style: normalize line endings to match .editorconfig"
 
 After this commit, `./scripts/format.sh` (or `dotnet format`) runs in CI and must report no changes.
 
+Run `npx prettier --check .` and `npx markdownlint-cli2` to verify documentation formatting. See `AGENTS.md` for configuration details.
+
 ## License
 
 This project is licensed under the [MIT](LICENSE) license.
-


### PR DESCRIPTION
## Summary
- clarify contribution setup to run Prettier and markdownlint
- document the lint commands in README
- note markdown/Prettier rules in AGENTS

## Testing
- `dotnet restore WebDownloadr.sln`
- `./scripts/selfcheck.sh`
- `npx prettier --check README.md CONTRIBUTING.md AGENTS.md`
- `npx markdownlint-cli2 README.md CONTRIBUTING.md AGENTS.md`


------
https://chatgpt.com/codex/tasks/task_e_686eead52818832d9e49fcf6f159dd75