### PR TITLE
[Build] install dotnet 9 via apt

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -724,13 +724,13 @@ When tasks are ambiguous, consider asking:
 
 ## Runtime Environment
 
-- **.NET SDK 9.0.301** must be on the `PATH` (see `global.json`).
+- **.NET SDK 9.x** must be on the `PATH` (see `global.json`).
 
 - The reference build environment is Ubuntu 22.04 (Docker image `mcr.microsoft.com/dotnet/sdk:9.0`).
 
-- Run `./scripts/setup-codex.sh` to ensure the SDK and required global tools are installed. Sourcing this script sets `DOTNET_ROOT` and
-  updates the `PATH` for the current shell, persisting them in `~/.bashrc`. It invokes `setup-dotnet.sh` and `install-tools.sh` under the
-  hood. If new tools are added, update those scripts and document their use here or in `CONTRIBUTING.md`.
+- Run `./scripts/setup-codex.sh` to install the SDK via the `dotnet/backports` PPA and required global tools. Sourcing this script sets `DOTNET_ROOT`
+  and updates the `PATH` for the current shell, persisting them in `~/.bashrc`.
+
 
 ## Allowed Tools & APIs
 

--- a/scripts/setup-codex.sh
+++ b/scripts/setup-codex.sh
@@ -3,8 +3,25 @@ set -euo pipefail
 
 cd "$(dirname "$0")/.."
 
-# Source setup-dotnet so PATH updates propagate
-source ./scripts/setup-dotnet.sh
+# Install .NET 9 SDK via dotnet/backports if not already present
+if ! command -v dotnet >/dev/null || ! [[ $(dotnet --version) =~ ^9\. ]]; then
+  apt-get update
+  apt-get install -y software-properties-common
+  add-apt-repository -y ppa:dotnet/backports
+  apt-get update
+  apt-get install -y dotnet-sdk-9.0
+fi
+
+export DOTNET_ROOT="/usr/lib/dotnet"
+export PATH="$DOTNET_ROOT:$DOTNET_ROOT/tools:$HOME/.local/bin:$PATH"
+
+if ! grep -q '^export DOTNET_ROOT=' ~/.bashrc; then
+  cat <<'EOF' >> ~/.bashrc
+export DOTNET_ROOT="/usr/lib/dotnet"
+export PATH="$DOTNET_ROOT:$DOTNET_ROOT/tools:$HOME/.local/bin:$PATH"
+EOF
+fi
+
 ./scripts/install-tools.sh
 
 echo "✅ Codex environment ready."


### PR DESCRIPTION
## Summary
- install `.NET` 9 SDK using dotnet/backports PPA in `setup-codex.sh`
- drop old `dotnet-install.sh` fallback
- document .NET 9 SDK requirement

## Testing
- `bash scripts/setup-codex.sh`
- `dotnet restore WebDownloadr.sln`
- `./scripts/selfcheck.sh`

------
https://chatgpt.com/codex/tasks/task_e_686eec6591a4832d9f463f2f8f534caf