### PR TITLE
Fix YAML syntax in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,8 @@ jobs:
       - name: Restore solution
         run: dotnet restore WebDownloadr.sln
 
-      - name: Selfcheck script        run: ./scripts/selfcheck.sh
+      - name: Selfcheck script
+        run: ./scripts/selfcheck.sh
       - name: Validate commit messages
         run: npx commitlint --from ${{ github.event.before }} --to ${{ github.sha }}
 


### PR DESCRIPTION
## Summary
- correct formatting of the `Selfcheck script` step

## Testing
- `./scripts/setup-codex.sh`
- `dotnet restore WebDownloadr.sln`
- `./scripts/selfcheck.sh` *(fails: markdown lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_686eef4fa674832daa1d7e29d41720f2