### PR TITLE
LF line endings

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -74,7 +74,7 @@ dotnet_naming_symbols.private_fields.applicable_accessibilities = private
 dotnet_naming_style.prefix_underscore.capitalization = camel_case
 dotnet_naming_style.prefix_underscore.required_prefix = _
 dotnet_style_operator_placement_when_wrapping = beginning_of_line
-end_of_line = crlf
+end_of_line = lf
 ###############################
 # C# Coding Conventions       #
 ###############################

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,18 @@
-# Enforce CRLF for text files; keep shell scripts LF
-* text eol=crlf
-*.sh text eol=lf
+# Enforce LF line endings for text files
+* text=auto eol=lf
+
+# Shell and PowerShell scripts always LF
+*.sh eol=lf
+*.ps1 eol=lf
+
+# Windows batch files keep CRLF
+*.bat eol=crlf
+*.cmd eol=crlf
+
+# Binary files
 *.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.ico binary
+*.zip binary

--- a/README.md
+++ b/README.md
@@ -35,10 +35,10 @@ Additional documentation lives in the `docs` folder and within each project. Sta
 
 ## Formatting
 
-Formatting is enforced in CI. Configure Git to honor `.editorconfig` line endings:
+Formatting is enforced in CI. All text files use LF endings. Configure Git to convert CRLF on commit:
 
 ```bash
-git config --global core.autocrlf true
+git config --global core.autocrlf input
 ```
 
 For the initial bootstrap, maintainers should normalize all files and format the solution:
@@ -48,6 +48,8 @@ git add --renormalize .
 git commit -m "style: normalize line endings to match .editorconfig"
 ./scripts/bootstrap-format.sh --commit
 ```
+
+The repository's `.gitattributes` enforces LF for text files and marks common binaries.
 
 After this commit, `./scripts/format.sh` (or `dotnet format`) runs in CI and must report no changes.
 


### PR DESCRIPTION
## Summary
- enforce LF endings in .gitattributes
- update .editorconfig to use LF
- update README with new line-ending policy
- renormalize repository

## Testing
- `dotnet restore WebDownloadr.sln`
- `./scripts/selfcheck.sh`

------
https://chatgpt.com/codex/tasks/task_e_686f06469f00832dbeda44f7e731c376