### PR TITLE
Add pre-commit and EOL checks

### DIFF
--- a/.github/workflows/eol-check.yml
+++ b/.github/workflows/eol-check.yml
@@ -1,0 +1,22 @@
+name: EOL Check
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  check-crlf:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Detect CRLF line endings
+        run: |
+          bad=$(git ls-files -z | xargs -0 grep -Il $'\r' || true)
+          if [ -n "$bad" ]; then
+            echo "::error title=CRLF detected::Files contain CRLF line endings"
+            echo "$bad"
+            exit 1
+          fi
+

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,6 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.5.0
+    hooks:
+      - id: mixed-line-ending
+        args: [--fix=lf]

--- a/README.md
+++ b/README.md
@@ -55,6 +55,18 @@ After this commit, `./scripts/format.sh` (or `dotnet format`) runs in CI and mus
 
 Run `npx prettier --check .` and `npx markdownlint-cli2` to verify documentation formatting. See `AGENTS.md` for configuration details.
 
+## Pre-commit
+
+Install [pre-commit](https://pre-commit.com/) and set up the git hook:
+
+```bash
+pip install pre-commit
+pre-commit install
+```
+
+Running `pre-commit` will execute the hooks defined in `.pre-commit-config.yaml`.
+
+
 ## License
 
 This project is licensed under the [MIT](LICENSE) license.


### PR DESCRIPTION
## Summary
- add pre-commit config to normalize line endings
- fail CI when CRLF line endings are present
- document pre-commit setup in README

## Testing
- `dotnet restore WebDownloadr.sln`
- `./scripts/selfcheck.sh` *(fails: npm warn Unknown env config)*

------
https://chatgpt.com/codex/tasks/task_e_686f0866850c832db5b1c3473a542c15