### PR TITLE
[Scripts] chore: clean up selfcheck script

### DIFF
--- a/scripts/selfcheck.sh
+++ b/scripts/selfcheck.sh
@@ -21,5 +21,3 @@ npx --yes prettier --check "**/*.md"
 # Validate commit messages
 npm install --no-save @commitlint/config-conventional
 npx --yes commitlint --from HEAD~1
-npx --yes markdownlint-cli2 "**/*.md" "#node_modules"
-npx --yes prettier --check "**/*.md"


### PR DESCRIPTION
## Summary
- remove extra markdownlint and prettier steps
- run commitlint once

## Testing
- `dotnet restore WebDownloadr.sln`
- `./scripts/selfcheck.sh`

------
https://chatgpt.com/codex/tasks/task_e_686f09debf40832dbc33eb858a42d9df