### PR TITLE
[Web] fix delete contributor endpoint

### DIFF
--- a/src/WebDownloadr.Web/Contributors/Delete.cs
+++ b/src/WebDownloadr.Web/Contributors/Delete.cs
@@ -35,7 +35,6 @@ public class Delete(IMediator _mediator)
     {
       await SendNoContentAsync(cancellationToken);
     }
-    ;
     // TODO: Handle other issues as needed
   }
 }

--- a/tests/WebDownloadr.FunctionalTests/ApiEndpoints/ContributorDelete.cs
+++ b/tests/WebDownloadr.FunctionalTests/ApiEndpoints/ContributorDelete.cs
@@ -1,0 +1,24 @@
+﻿using WebDownloadr.Infrastructure.Data;
+using WebDownloadr.Web.Contributors;
+
+namespace WebDownloadr.FunctionalTests.ApiEndpoints;
+
+[Collection("Sequential")]
+public class ContributorDelete(CustomWebApplicationFactory<Program> factory) : IClassFixture<CustomWebApplicationFactory<Program>>
+{
+  private readonly HttpClient _client = factory.CreateClient();
+
+  [Fact]
+  public async Task DeletesContributorGivenValidId()
+  {
+    string route = DeleteContributorRequest.BuildRoute(SeedData.Contributor1.Id);
+    _ = await _client.DeleteAndEnsureNoContentAsync(route);
+  }
+
+  [Fact]
+  public async Task ReturnsNotFoundGivenInvalidId()
+  {
+    string route = DeleteContributorRequest.BuildRoute(1000);
+    _ = await _client.DeleteAndEnsureNotFoundAsync(route);
+  }
+}

--- a/tests/WebDownloadr.FunctionalTests/CustomWebApplicationFactory.cs
+++ b/tests/WebDownloadr.FunctionalTests/CustomWebApplicationFactory.cs
@@ -1,4 +1,6 @@
-﻿using WebDownloadr.Infrastructure.Data;
+﻿using WebDownloadr.Core.Interfaces;
+using WebDownloadr.Infrastructure.Data;
+using WebDownloadr.Infrastructure.Email;
 
 namespace WebDownloadr.FunctionalTests;
 
@@ -60,26 +62,13 @@ public class CustomWebApplicationFactory<TProgram> : WebApplicationFactory<TProg
     builder
         .ConfigureServices(services =>
         {
-          // Configure test dependencies here
-
-          //// Remove the app's ApplicationDbContext registration.
-          //var descriptor = services.SingleOrDefault(
-          //d => d.ServiceType ==
-          //    typeof(DbContextOptions<AppDbContext>));
-
-          //if (descriptor != null)
-          //{
-          //  services.Remove(descriptor);
-          //}
-
-          //// This should be set for each individual test run
-          //string inMemoryCollectionName = Guid.NewGuid().ToString();
-
-          //// Add ApplicationDbContext using an in-memory database for testing.
-          //services.AddDbContext<AppDbContext>(options =>
-          //{
-          //  options.UseInMemoryDatabase(inMemoryCollectionName);
-          //});
+          // Replace email sender with fake implementation
+          var descriptor = services.SingleOrDefault(d => d.ServiceType == typeof(IEmailSender));
+          if (descriptor != null)
+          {
+            services.Remove(descriptor);
+          }
+          services.AddScoped<IEmailSender, FakeEmailSender>();
         });
   }
 }


### PR DESCRIPTION
## Summary
- remove stray semicolon after SendNoContentAsync in Delete endpoint
- override email sender in functional tests to avoid SMTP calls
- add contributor delete functional tests

## Testing
- `./scripts/selfcheck.sh`

------
https://chatgpt.com/codex/tasks/task_e_686f0abefdf4832dbd4d774376fcb806