### PR TITLE
Align commit guidance with Conventional Commits

### DIFF
--- a/.commitlintrc.json
+++ b/.commitlintrc.json
@@ -12,6 +12,7 @@
       ["core","usecases","infrastructure","web","tests","scripts","docs","adr"]
     ],
     "scope-case": [2, "always", "lower-case"],
+    "scope-empty": [2, "never"],
     "subject-max-length": [2, "always", 72],
     "subject-case": [2, "never", ["sentence-case","start-case","pascal-case","upper-case"]]
   }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -381,8 +381,7 @@ _Only add if UI requirements outgrow FastEndpoints._
    The script runs `dotnet` build/test, architecture checks, formatting, `markdownlint-cli2`, `prettier --check`, and `commitlint`. The
    script **must exit 0**; fix any errors before continuing.
 
-3. **Commit changes** Follow [Conventional Commits](#commit-message-format) with a layer prefix, e.g.
-   `[UseCases] feat: add download queue processor`
+3. **Commit changes** Follow [Conventional Commits](#commit-message-format), for example `feat(usecases): add download queue processor`
 
 4. **Push and open a Pull Request** Title the PR `[Layer] <summary>` and complete the PR template (link issues, add screenshots/tests as
    needed).
@@ -1284,7 +1283,7 @@ Follow this safety protocol whenever requirements are ambiguous:
 | **90 %+ coverage**                         | High confidence that business logic remains correct; enforced in CI.               |
 | **ADR for every big decision**             | Preserves architectural history; no “Why did we choose X?” mysteries.              |
 | **No secrets in repo**                     | Security first; use User Secrets or CI vaults.                                     |
-| **Commit style: `[Layer] type: summary`**  | Lets humans & CI trace changes by layer and intent.                                |
+| **Commit style: `type(scope): summary`**   | Lets humans & CI trace changes by layer and intent.                                |
 | **Run `./scripts/selfcheck.sh` before PR** | Guarantees local build = CI build; saves back-and-forth fixes.                     |
 | **Generated code exceptions**              | EF migrations & snapshots bypass analyzers; avoids pointless linter noise.         |
 | **Ask clarifying questions**               | AI (and humans) should pause if requirements are ambiguous—better than guessing.   |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ Thank you for helping improve **WebDownloadr**. This repository follows the work
 
 1. Run `./scripts/setup-codex.sh` to install the .NET SDK and required global tools.
 2. Execute `./scripts/selfcheck.sh` (build, tests, formatting, `markdownlint-cli2`, and `prettier --check`) and make sure it exits with `0`.
-3. Commit using the format `[Layer] <type>: <summary>` following [Conventional Commits](https://www.conventionalcommits.org/).
+3. Commit using the format `type(scope): <summary>` following [Conventional Commits](https://www.conventionalcommits.org/).
 
 ## Pull Requests
 


### PR DESCRIPTION
## Summary
- update commit workflow docs in AGENTS.md
- refine quick reference commit style
- clarify CONTRIBUTING instructions
- require a scope in `.commitlintrc.json`

## Testing
- `./scripts/setup-codex.sh`
- `./scripts/selfcheck.sh`

------
https://chatgpt.com/codex/tasks/task_e_686f14d1fec4832daf539c301d96b673