### PR TITLE
docs: fix AGENTS lint failures

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,19 +67,19 @@ This repository uses a layered architecture for maintainability, clear separatio
 - **Output Format:** All code, config, and documentation output by AI agents must be in valid, ready-to-commit format. Use the file block syntax specified by Copilot Spaces.
 - **Prompt Engineering:** Avoid forbidden prompt styles (see [Appendix A](#appendix-a-forbidden-prompt-styles)).
 - **Resource Limits:**
-    - Max 5 HTTP calls/run
-    - Max 512MB memory
-    - Max 60s execution per task
+  - Max 5 HTTP calls/run
+  - Max 512MB memory
+  - Max 60s execution per task
 - **Inheritance:** Respect local AGENTS.md overrides (see [Section 4](#4-layer-inheritance--overrides)).
 - **Security:** Never leak secrets or PII in output.
 - **Improving Instructions:** AI agents should recommend updates to these instructions if it would improve the contribution, review, or automation process. Such recommendations should be submitted as a draft issue or pull request for human review.
 - **Common Mistakes to Avoid:**
-    - ❌ Proposing code that directly accesses the database from UseCases
-    - ❌ Omitting test or documentation updates when logic changes
-    - ❌ Suggesting changes to AGENTS.md in subfolders without inheriting from parent
-    - ❌ Outputting non-deterministic or ambiguous code or text
-    - ✅ Output stepwise reasoning for architectural decisions
-    - ✅ Escalate to human review when uncertain
+  - ❌ Proposing code that directly accesses the database from UseCases
+  - ❌ Omitting test or documentation updates when logic changes
+  - ❌ Suggesting changes to AGENTS.md in subfolders without inheriting from parent
+  - ❌ Outputting non-deterministic or ambiguous code or text
+  - ✅ Output stepwise reasoning for architectural decisions
+  - ✅ Escalate to human review when uncertain
 
 ---
 
@@ -109,45 +109,45 @@ AGENTS.md may exist in any subdirectory, including code, test, or documentation 
 **Scripts & Setup:**
 The `/scripts` folder contains tooling for environment setup and enforcement of repository standards:
 
-* `setup-codex.sh`: Sets up the Codex agent environment.
-* `setup-dotnet.sh`: Installs .NET 9 dependencies.
-* `install-tools.sh`: Installs additional .NET 9 tools.
-* `archtest.sh`: Enforces architectural boundaries via ArchUnitNET or NetArchTest.
-* `selfcheck.sh`: Bundled script to run all quality gates (restore, build, test, format, lint, etc).
+- `setup-codex.sh`: Sets up the Codex agent environment.
+- `setup-dotnet.sh`: Installs .NET 9 dependencies.
+- `install-tools.sh`: Installs additional .NET 9 tools.
+- `archtest.sh`: Enforces architectural boundaries via ArchUnitNET or NetArchTest.
+- `selfcheck.sh`: Bundled script to run all quality gates (restore, build, test, format, lint, etc).
   Run `./scripts/selfcheck.sh -h` for options (e.g., `--skip-test`, `--only-format`).
 
 **Formatting (Run Before Checking):**
 
-* Run `dotnet format` to auto-format C# code.
-* Run `shfmt -w` to format shell scripts.
-* Run `prettier --write .` for Markdown, JSON, and web assets (if applicable).
+- Run `dotnet format` to auto-format C# code.
+- Run `shfmt -w` to format shell scripts.
+- Run `prettier --write .` for Markdown, JSON, and web assets (if applicable).
 
 **Linting:**
 
-* `commitlint`: Enforces commit message conventions.
-* `eslint`: Used for JavaScript/TypeScript files (if applicable).
-* `markdownlint-cli2`: Validates Markdown documentation style.
+- `commitlint`: Enforces commit message conventions.
+- `eslint`: Used for JavaScript/TypeScript files (if applicable).
+- `markdownlint-cli2`: Validates Markdown documentation style.
 
 **Tests:**
 
-* All code must pass unit and integration tests via `dotnet test` or `selfcheck.sh`.
+- All code must pass unit and integration tests via `dotnet test` or `selfcheck.sh`.
 
 **Coverage:**
 
-* Pull requests must not reduce test coverage (enforced via `/ci/coverage.yml`).
+- Pull requests must not reduce test coverage (enforced via `/ci/coverage.yml`).
 
 **CI/CD:**
 
-* Pre-commit and CI pipelines enforce all formatting, linting, and architectural rules.
-* See `/ci/` for full configuration details.
+- Pre-commit and CI pipelines enforce all formatting, linting, and architectural rules.
+- See `/ci/` for full configuration details.
 
 **Automation:**
 
-* All quality gates are enforced by:
+- All quality gates are enforced by:
 
-    * Git pre-commit hooks (optional but recommended),
-    * GitHub Actions or equivalent CI,
-    * `selfcheck.sh` for local validation before PR.
+  - Git pre-commit hooks (optional but recommended),
+  - GitHub Actions or equivalent CI,
+  - `selfcheck.sh` for local validation before PR.
 
 ---
 
@@ -156,48 +156,49 @@ The `/scripts` folder contains tooling for environment setup and enforcement of 
 This repository follows [Ardalis Clean Architecture](https://github.com/ardalis/CleanArchitecture). Examples and patterns below illustrate common usage; refer to [Section 1](#1-project-structure-and-layering) for the canonical structure and dependency rules.
 
 1. **CQRS (Command Query Responsibility Segregation):**
-    - Commands: `src/WebDownloadr.UseCases/Commands/`
-    - Queries: `src/WebDownloadr.UseCases/Queries/`
-    - Pattern: Commands encapsulate writes; queries encapsulate reads. Both use the Mediator pattern to decouple sender and receiver.
+  - Commands: `src/WebDownloadr.UseCases/Commands/`
+  - Queries: `src/WebDownloadr.UseCases/Queries/`
+  - Pattern: Commands encapsulate writes; queries encapsulate reads. Both use the Mediator pattern to decouple sender and receiver.
 
 2. **Domain Events:**
-    - Events: `src/WebDownloadr.Core/DomainEvents/`
-    - Handlers: `src/WebDownloadr.UseCases/EventHandlers/`
-    - Pattern: Business rules enforced in the domain layer via events/handlers.
+  - Events: `src/WebDownloadr.Core/DomainEvents/`
+  - Handlers: `src/WebDownloadr.UseCases/EventHandlers/`
+  - Pattern: Business rules enforced in the domain layer via events/handlers.
 
 3. **Specification Pattern:**
-    - Specs: `src/WebDownloadr.Core/Specifications/`
-    - Usage: `src/WebDownloadr.Infrastructure/Data/Repositories/`
-    - Pattern: Complex queries encapsulated as reusable specifications.
+  - Specs: `src/WebDownloadr.Core/Specifications/`
+  - Usage: `src/WebDownloadr.Infrastructure/Data/Repositories/`
+  - Pattern: Complex queries encapsulated as reusable specifications.
 
 4. **Dependency Injection (DI):**
-    - Setup: `src/WebDownloadr.Web/Program.cs`
-    - Pattern: Use ASP.NET Core’s DI container for dependency resolution.
+  - Setup: `src/WebDownloadr.Web/Program.cs`
+  - Pattern: Use ASP.NET Core’s DI container for dependency resolution.
 
 5. **Unit of Work and Repository:**
-    - Repositories: `src/WebDownloadr.Infrastructure/Data/Repositories/`
-    - Unit of Work: `src/WebDownloadr.Infrastructure/Data/UnitOfWork`
-    - Pattern: Data access abstracted; transactions managed via Unit of Work.
+  - Repositories: `src/WebDownloadr.Infrastructure/Data/Repositories/`
+  - Unit of Work: `src/WebDownloadr.Infrastructure/Data/UnitOfWork`
+  - Pattern: Data access abstracted; transactions managed via Unit of Work.
 
 6. **Adapters and Ports:**
-    - Adapters: `src/WebDownloadr.Infrastructure/Data/Adapters/`
-    - Ports: `src/WebDownloadr.Core/Interfaces/`
-    - Pattern: Ports and Adapters isolates external dependencies from domain.
+  - Adapters: `src/WebDownloadr.Infrastructure/Data/Adapters/`
+  - Ports: `src/WebDownloadr.Core/Interfaces/`
+  - Pattern: Ports and Adapters isolates external dependencies from domain.
 
 7. **API Endpoints:**
-    - Endpoints: `src/WebDownloadr.Web/Endpoints/`
-    - Pattern: [FastEndpoints](https://fast-endpoints.com/docs/introduction) exposes business logic from UseCases.
+  - Endpoints: `src/WebDownloadr.Web/Endpoints/`
+  - Pattern: [FastEndpoints](https://fast-endpoints.com/docs/introduction) exposes business logic from UseCases.
 
 8. **Testing:**
-    - Unit: `tests/WebDownloadr.UnitTests/`
-    - Integration: `tests/WebDownloadr.IntegrationTests/`
-    - Functional: `tests/WebDownloadr.FunctionalTests/`
-    - Pattern: All new/modified code must be covered by tests.
+  - Unit: `tests/WebDownloadr.UnitTests/`
+  - Integration: `tests/WebDownloadr.IntegrationTests/`
+  - Functional: `tests/WebDownloadr.FunctionalTests/`
+  - Pattern: All new/modified code must be covered by tests.
 
 #### Example: AI Agent PR Output
 - PR Title: `feat: add download domain event and handler`
 - Commit Message:
-  ```
+
+  ```text
   feat(core): add DownloadCompleted domain event
 
   - Adds DownloadCompleted domain event to Core
@@ -215,33 +216,33 @@ This repository follows [Ardalis Clean Architecture](https://github.com/ardalis/
 
 ### 7.1. Dependency & Import Rules
 - Only reference and import from your own layer and lower.
-    - See [Section 1](#1-project-structure-and-layering) and [Section 4](#4-layer-inheritance--overrides).
-    - **Forbidden:** Upwards or lateral imports (e.g., Web importing from Infrastructure, UseCases referencing Web).
-    - **External packages:** Allowed only if justified in your layer’s AGENTS.md or Core documentation.
+  - See [Section 1](#1-project-structure-and-layering) and [Section 4](#4-layer-inheritance--overrides).
+  - **Forbidden:** Upwards or lateral imports (e.g., Web importing from Infrastructure, UseCases referencing Web).
+  - **External packages:** Allowed only if justified in your layer’s AGENTS.md or Core documentation.
 - Cyclic dependencies are strictly prohibited.
-    - Enforced with [`archtest.sh`](./scripts/archtest.sh) and architectural test suites.
+  - Enforced with [`archtest.sh`](./scripts/archtest.sh) and architectural test suites.
 
 ### 7.2. Naming Conventions
 - **Classes & Types:** `PascalCase` (e.g., `DownloadRequestHandler`)
 - **Variables & Parameters:** `camelCase` (e.g., `downloadUrl`)
 - **Files:**
-    - C#: `PascalCase` (e.g., `UserService.cs`)
-    - Scripts: `kebab-case.sh` (e.g., `setup-codex.sh`)
+  - C#: `PascalCase` (e.g., `UserService.cs`)
+  - Scripts: `kebab-case.sh` (e.g., `setup-codex.sh`)
 - **Branches:**
-    - Features: `feature/<concise-description>`
-    - Fixes: `fix/<concise-description>`
-    - Docs: `docs/<concise-description>`
+  - Features: `feature/<concise-description>`
+  - Fixes: `fix/<concise-description>`
+  - Docs: `docs/<concise-description>`
 
 ### 7.3. Commit & PR Standards
 - **Commit messages:**
-    - Use [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `docs:`, etc.).
-    - Reference issues where relevant.
+  - Use [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `docs:`, etc.).
+  - Reference issues where relevant.
 - **PRs:**
-    - PR titles should be descriptive and match commit conventions.
-    - Reference related issues in the PR description.
+  - PR titles should be descriptive and match commit conventions.
+  - Reference related issues in the PR description.
 - **Issue/PR templates:**
-    - Use templates in [`.github/`](./.github/).
-    - Fill out all required fields.
+  - Use templates in [`.github/`](./.github/).
+  - Fill out all required fields.
 
 ### 7.4. Coding & Documentation Standards
 - All code changes must include or update corresponding tests in `/tests`.
@@ -264,7 +265,7 @@ This repository follows [Ardalis Clean Architecture](https://github.com/ardalis/
 
 ## 9. Appendices
 
-### Appendix A: Forbidden Prompt Styles 🤖
+### Appendix A: Forbidden Prompt Styles
 
 - No open-ended “do anything” prompts.
 - No request for code execution outside the prescribed CI/CD context.

--- a/docs/architecture-decisions/AGENTS.md
+++ b/docs/architecture-decisions/AGENTS.md
@@ -27,48 +27,48 @@
 ## 2. ADR Structure & Conventions
 
 - **Format:**
-    - All ADRs must follow [Michael Nygard’s template](https://github.com/joelparkerhenderson/architecture-decision-record/tree/main/locales/en/templates/decision-record-template-by-michael-nygard) (status, context, decision, consequences, etc).
-    - Use Markdown files, named sequentially: `0001-title.md`, `0002-another-decision.md`, etc.
+  - All ADRs must follow [Michael Nygard’s template](https://github.com/joelparkerhenderson/architecture-decision-record/tree/main/locales/en/templates/decision-record-template-by-michael-nygard) (status, context, decision, consequences, etc).
+  - Use Markdown files, named sequentially: `0001-title.md`, `0002-another-decision.md`, etc.
 - **File Naming:**
-    - Use all lowercase, words separated by hyphens.
-    - Prefix with a 4-digit ADR number (e.g., `0003-use-fastendpoints.md`).
+  - Use all lowercase, words separated by hyphens.
+  - Prefix with a 4-digit ADR number (e.g., `0003-use-fastendpoints.md`).
 - **Status:**
-    - Each ADR must have a `Status:` field (`Proposed`, `Accepted`, `Superseded`, `Deprecated`, `Rejected`).
+  - Each ADR must have a `Status:` field (`Proposed`, `Accepted`, `Superseded`, `Deprecated`, `Rejected`).
 
 ---
 
 ## 3. Contribution & Review Workflow
 
 - **Proposing an ADR:**
-    - Add a new Markdown file as described above.
-    - Reference related issues or discussions in the ADR.
-    - Submit as a Pull Request (PR) targeting the main branch.
+  - Add a new Markdown file as described above.
+  - Reference related issues or discussions in the ADR.
+  - Submit as a Pull Request (PR) targeting the main branch.
 - **Review & Acceptance:**
-    - All ADRs must be reviewed by at least one core maintainer before acceptance.
-    - Status should be updated to `Accepted` or `Rejected` as appropriate during review.
+  - All ADRs must be reviewed by at least one core maintainer before acceptance.
+  - Status should be updated to `Accepted` or `Rejected` as appropriate during review.
 - **Superseding or Updating ADRs:**
-    - When an ADR is replaced, clearly mark it as `Superseded` and reference the new ADR number.
+  - When an ADR is replaced, clearly mark it as `Superseded` and reference the new ADR number.
 
 ---
 
 ## 4. AI Agent Rules 🤖
 
 - **Consistency:**
-    - Use the same ADR template and file naming conventions as humans.
+  - Use the same ADR template and file naming conventions as humans.
 - **Traceability:**
-    - Reference the context or discussions that justify the decision.
+  - Reference the context or discussions that justify the decision.
 - **Self-Validation:**
-    - AI agents must check that all required ADR sections are present and complete.
+  - AI agents must check that all required ADR sections are present and complete.
 - **Escalation:**
-    - If requirements are unclear or context is missing, propose an ADR draft and tag a maintainer for review.
+  - If requirements are unclear or context is missing, propose an ADR draft and tag a maintainer for review.
 - **Improvement Recommendations:**
-    - AI agents should recommend updates to this AGENTS.md if better practices or automation can be identified (see [Section 6](#6-maintenance--improvement)).
+  - AI agents should recommend updates to this AGENTS.md if better practices or automation can be identified (see [Section 6](#6-maintenance--improvement)).
 - **Output Format:**
-    - All ADRs and communications must be in valid Markdown, ready for review and commit.
+  - All ADRs and communications must be in valid Markdown, ready for review and commit.
 - **Common Mistakes to Avoid:**
-    - ❌ Omitting status or context in ADRs
-    - ❌ Using ambiguous or generic titles
-    - ❌ Failing to link related issues, discussions, or superseded ADRs
+  - ❌ Omitting status or context in ADRs
+  - ❌ Using ambiguous or generic titles
+  - ❌ Failing to link related issues, discussions, or superseded ADRs
 
 ---
 
@@ -78,6 +78,7 @@
 `0004-adopt-aspire-for-service-orchestration.md`
 
 **Header Example:**
+
 ```markdown
 # 0004: Adopt .NET Aspire for Service Orchestration
 


### PR DESCRIPTION
## Summary
- fix unordered list markers and indentation in AGENTS docs
- ensure fenced code blocks have language and spacing
- fix Appendix A heading and trailing newlines

## Testing
- `./scripts/selfcheck.sh --skip-build --skip-test` *(fails: The argument /workspace/webdownloadr/tests/WebDownloadr.ArchTests/bin/Debug/net9.0/WebDownloadr.ArchTests.dll is invalid)*

------
https://chatgpt.com/codex/tasks/task_e_6871093cba40832dbc04628238d72258