### PR TITLE
Fix duplicate heading in Infrastructure AGENTS

### DIFF
--- a/src/WebDownloadr.Infrastructure/AGENTS.md
+++ b/src/WebDownloadr.Infrastructure/AGENTS.md
@@ -37,7 +37,7 @@
 - External adapters each get their own top‑level folder; the shipped template includes only **Email** by default.
 - If you add more adapters (e.g., `Files/`), follow the same flat folder pattern and keep one public type per file.
 
-## 3  Data Access (EF Core)  Data Access (EF Core)
+## 3  Data Access (EF Core)
 
 ### 3.1  AppDbContext
 


### PR DESCRIPTION
## Summary
- fix duplicate "Data Access" heading in Infrastructure AGENTS file

## Testing
- `./scripts/selfcheck.sh --skip-test --skip-arch --skip-commitlint`

------
https://chatgpt.com/codex/tasks/task_e_6874d07984c0832da13a6276b72832d3