### PR TITLE
docs: format Markdown files with Prettier

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -5,25 +5,28 @@ This document lists the current maintainers of the WebDownloadr project and prov
 ## Core Maintainers
 
 ### Project Lead
+
 - **Primary Contact**: Berin Iwlew
 - **GitHub**: [@beriniwlew](https://github.com/beriniwlew)
 - **Responsibilities**: Architecture decisions, major feature reviews, release management
 
-
 ## Maintainer Guidelines
 
 ### Review Responsibilities
+
 - **Core Maintainers**: Review all architectural changes, breaking changes, and major features
 - **Technical Maintainers**: Review changes in their respective areas
 - **All Maintainers**: Review documentation updates, dependency updates, and security patches
 
 ### Response Times
+
 - **Critical Issues**: 24 hours
 - **Feature Requests**: 1 week
 - **Documentation**: 1 week
 - **AI Agent Escalations**: 48 hours
 
 ### Escalation Process
+
 1. **AI Agent Escalations**: Create GitHub Issue with `ai-agent-escalation` label
 2. **Architecture Decisions**: Follow ADR process in `docs/architecture-decisions/`
 3. **Security Issues**: Create private security issue or contact maintainers directly
@@ -32,19 +35,21 @@ This document lists the current maintainers of the WebDownloadr project and prov
 ## Contact Information
 
 ### For Contributors
+
 - **General Questions**: Create GitHub Issue with appropriate label
 - **Code Reviews**: Request review from relevant technical maintainer
 - **Architecture Questions**: Use ADR process or tag core maintainers
 
 ### For AI Agents
+
 - **Escalations**: Create issue with `ai-agent-escalation` label
 - **Uncertain Rules**: Tag maintainers in issue description
 - **Architecture Decisions**: Follow ADR process
 
-
 ## Maintainer Onboarding
 
 ### New Maintainer Checklist
+
 - [ ] Read and understand AGENTS.md
 - [ ] Review architecture decisions in `docs/architecture-decisions/`
 - [ ] Set up development environment using scripts in `/scripts`
@@ -53,6 +58,7 @@ This document lists the current maintainers of the WebDownloadr project and prov
 - [ ] Join maintainer communication channels
 
 ### Maintainer Offboarding
+
 - [ ] Transfer ownership of assigned areas
 - [ ] Update contact information in this file
 - [ ] Archive or transfer personal repositories
@@ -61,16 +67,18 @@ This document lists the current maintainers of the WebDownloadr project and prov
 ## Decision Making
 
 ### Consensus Process
+
 - **Minor Changes**: Single maintainer approval
 - **Feature Additions**: Two maintainer approvals
 - **Breaking Changes**: All core maintainer approvals
 - **Architecture Changes**: ADR process + core maintainer approval
 
 ### Conflict Resolution
+
 - **Technical Disputes**: Architecture decision record (ADR)
 - **Process Disputes**: Core maintainer discussion
 - **Escalation**: Project lead makes final decision
 
 ---
 
-> **Note**: This file should be updated whenever maintainer information changes. All maintainers should have access to update this file. 
+> **Note**: This file should be updated whenever maintainer information changes. All maintainers should have access to update this file.

--- a/README.md
+++ b/README.md
@@ -16,9 +16,11 @@ separate projects that isolate the domain model, application services, infrastru
 
 ## Architecture Decisions
 
-This project uses [Architecture Decision Records (ADRs)](docs/architecture-decisions/README.md) to document significant architectural choices. Key decisions include:
+This project uses [Architecture Decision Records (ADRs)](docs/architecture-decisions/README.md) to document significant architectural
+choices. Key decisions include:
 
-- **[0001: Adopt Clean Architecture](docs/architecture-decisions/0001-adopt-clean-architecture.md)** – Foundation for the layered architecture
+- **[0001: Adopt Clean Architecture](docs/architecture-decisions/0001-adopt-clean-architecture.md)** – Foundation for the layered
+  architecture
 - **[0002: Optimize AGENTS Usage](docs/architecture-decisions/0002-optimize-agents-usage.md)** – Standardized contribution guidelines
 - **[0003: Web Pages Functionality](docs/architecture-decisions/0003-web-pages-functionality.md)** – Domain-driven implementation approach
 - **[0004: .NET DI Adoption](docs/architecture-decisions/0004-dotnet-di-adoption.md)** – Technology choice for dependency injection

--- a/docs/architecture-decisions/0000-template.md
+++ b/docs/architecture-decisions/0000-template.md
@@ -7,7 +7,8 @@ Superseded-by: N/A
 
 ## Context
 
-Explain the problem or forces driving this decision. Include relevant background information, constraints, and requirements that influenced the decision.
+Explain the problem or forces driving this decision. Include relevant background information, constraints, and requirements that influenced
+the decision.
 
 ## Decision
 
@@ -16,14 +17,17 @@ State the chosen option in one clear sentence. Be specific about what was decide
 ## Consequences
 
 **Positive outcomes:**
+
 - Benefit 1
 - Benefit 2
 
 **Negative outcomes:**
+
 - Trade-off 1
 - Trade-off 2
 
 **Follow-up tasks:**
+
 - Action item 1
 - Action item 2
 

--- a/docs/architecture-decisions/0001-adopt-clean-architecture.md
+++ b/docs/architecture-decisions/0001-adopt-clean-architecture.md
@@ -7,24 +7,30 @@ Superseded-by: N/A
 
 ## Context
 
-The project needs a structure that promotes maintainability, testability, and clear separation between business logic and external concerns. Clean Architecture organizes the codebase into distinct layers, isolating domain models from frameworks or infrastructure. This layered approach makes it easier to reason about dependencies and to evolve the system over time.
+The project needs a structure that promotes maintainability, testability, and clear separation between business logic and external concerns.
+Clean Architecture organizes the codebase into distinct layers, isolating domain models from frameworks or infrastructure. This layered
+approach makes it easier to reason about dependencies and to evolve the system over time.
 
 ## Decision
 
-Adopt the Clean Architecture pattern by structuring the solution into Core, UseCases, Infrastructure, and Web layers. Each layer will depend only on the layers below it, enforcing strict separation of concerns.
+Adopt the Clean Architecture pattern by structuring the solution into Core, UseCases, Infrastructure, and Web layers. Each layer will depend
+only on the layers below it, enforcing strict separation of concerns.
 
 ## Consequences
 
 **Positive outcomes:**
+
 - **Improved maintainability** through a well-defined layering strategy.
 - **Easier testing** because business logic can be exercised without infrastructure dependencies.
 - **Flexibility** to replace frameworks or external services without impacting the domain model.
 
 **Negative outcomes:**
+
 - Initial complexity in setting up the layered structure
 - Learning curve for team members unfamiliar with Clean Architecture
 
 **Follow-up tasks:**
+
 - Implement the layered project structure
 - Create interfaces for external dependencies
 - Set up dependency injection configuration
@@ -38,4 +44,3 @@ Adopt the Clean Architecture pattern by structuring the solution into Core, UseC
 
 - [Ardalis Clean Architecture](https://github.com/ardalis/CleanArchitecture)
 - [Clean Architecture by Uncle Bob](https://8thlight.com/blog/uncle-bob/2012/08/13/the-clean-architecture.html)
-

--- a/docs/architecture-decisions/0002-optimize-agents-usage.md
+++ b/docs/architecture-decisions/0002-optimize-agents-usage.md
@@ -7,26 +7,34 @@ Superseded-by: N/A
 
 ## Context
 
-This repository relies on `AGENTS.md` files to define contribution rules for humans and AI. The [root file](../../AGENTS.md) explains that these files can live in any subdirectory and that the most specific one overrides higher levels. Lines 86–103 outline known overrides such as `docs/architecture-decisions/` and remind contributors to always check for a local `AGENTS.md`.
+This repository relies on `AGENTS.md` files to define contribution rules for humans and AI. The [root file](../../AGENTS.md) explains that
+these files can live in any subdirectory and that the most specific one overrides higher levels. Lines 86–103 outline known overrides such
+as `docs/architecture-decisions/` and remind contributors to always check for a local `AGENTS.md`.
 
-Despite this guidance, some areas still lack clear inheritance patterns, leading to inconsistent rules for contributors and AI agents. Standardizing how these files are inherited will reduce confusion and ensure everyone follows the intended guidelines.
+Despite this guidance, some areas still lack clear inheritance patterns, leading to inconsistent rules for contributors and AI agents.
+Standardizing how these files are inherited will reduce confusion and ensure everyone follows the intended guidelines.
 
 ## Decision
 
-Adopt a standardized approach to `AGENTS.md` inheritance. Every major folder must either contain its own `AGENTS.md` or explicitly inherit from its nearest parent. Documentation will be updated to clarify this hierarchy so contributors and AI agents know which file governs their work.
+Adopt a standardized approach to `AGENTS.md` inheritance. Every major folder must either contain its own `AGENTS.md` or explicitly inherit
+from its nearest parent. Documentation will be updated to clarify this hierarchy so contributors and AI agents know which file governs their
+work.
 
 ## Consequences
 
 **Positive outcomes:**
+
 - **Improved Guidance**: Clearer rules in each folder help new contributors and automation follow repository standards.
 - **Easier Maintenance**: Standard inheritance reduces duplication and simplifies updates across the project.
 - **Consistent Agent Behavior**: AI tools can reliably determine applicable rules, minimizing errors due to mismatched instructions.
 
 **Negative outcomes:**
+
 - Initial effort required to create AGENTS.md files in all major folders
 - Need to maintain consistency across multiple AGENTS.md files
 
 **Follow-up tasks:**
+
 - Create AGENTS.md files in all major project folders
 - Update documentation to reflect the inheritance hierarchy
 - Train team members on the new structure
@@ -40,4 +48,3 @@ Adopt a standardized approach to `AGENTS.md` inheritance. Every major folder mus
 
 - Root `AGENTS.md` lines 86–103 show the current inheritance guidance
 - [AGENTS.md best practices](https://github.com/ardalis/CleanArchitecture/blob/main/AGENTS.md)
-

--- a/docs/architecture-decisions/0003-web-pages-functionality.md
+++ b/docs/architecture-decisions/0003-web-pages-functionality.md
@@ -7,26 +7,32 @@ Superseded-by: N/A
 
 ## Context
 
-The project requires functionality to download and manage web pages. This involves creating a system that can fetch web content, store it, and provide management capabilities. The implementation needs to be scalable, maintainable, and follow the established Clean Architecture patterns.
+The project requires functionality to download and manage web pages. This involves creating a system that can fetch web content, store it,
+and provide management capabilities. The implementation needs to be scalable, maintainable, and follow the established Clean Architecture
+patterns.
 
 ## Decision
 
-Implement web page functionality using a domain-driven approach with separate aggregates for WebPage and Contributor entities. Use CQRS pattern for separating read and write operations, and implement proper event handling for domain events.
+Implement web page functionality using a domain-driven approach with separate aggregates for WebPage and Contributor entities. Use CQRS
+pattern for separating read and write operations, and implement proper event handling for domain events.
 
 ## Consequences
 
 **Positive outcomes:**
+
 - **Clear separation of concerns** through domain aggregates
 - **Scalable architecture** that can handle multiple web page operations
 - **Event-driven design** enables loose coupling and extensibility
 - **CQRS pattern** provides optimal performance for read and write operations
 
 **Negative outcomes:**
+
 - Increased complexity compared to a simple CRUD approach
 - More initial development time required
 - Learning curve for team members unfamiliar with DDD patterns
 
 **Follow-up tasks:**
+
 - Implement WebPage aggregate with domain events
 - Create CQRS handlers for commands and queries
 - Set up event handlers for domain events

--- a/docs/architecture-decisions/0004-dotnet-di-adoption.md
+++ b/docs/architecture-decisions/0004-dotnet-di-adoption.md
@@ -7,32 +7,43 @@ Superseded-by: N/A
 
 ## Context
 
-Initially, this repository employed Autofac for dependency injection. At the time of adoption, Autofac was preferred due to its robust feature set, including:
+Initially, this repository employed Autofac for dependency injection. At the time of adoption, Autofac was preferred due to its robust
+feature set, including:
 
 - Support for advanced scenarios such as decorators and modules, which could be placed close to their corresponding implementations.
-- A well-established history of stability and maturity, having been used in various projects before .NET Core's built-in DI was fully featured.
+- A well-established history of stability and maturity, having been used in various projects before .NET Core's built-in DI was fully
+  featured.
 
-As the .NET ecosystem evolved, the built-in DI container began to meet the needs of our project without introducing the added complexity associated with Autofac. The .NET DI framework has matured significantly, offering sufficient functionality for typical use cases, including:
+As the .NET ecosystem evolved, the built-in DI container began to meet the needs of our project without introducing the added complexity
+associated with Autofac. The .NET DI framework has matured significantly, offering sufficient functionality for typical use cases,
+including:
 
 - Improved support for configuration through extension methods.
 - A simpler learning curve for new contributors familiar with .NET conventions.
 
 ## Decision
 
-Based on community feedback and a review of our project's requirements, we have decided to remove Autofac from this template and transition to using .NET's built-in dependency injection infrastructure. This decision aligns with the goal of simplifying the codebase and reducing external dependencies.
+Based on community feedback and a review of our project's requirements, we have decided to remove Autofac from this template and transition
+to using .NET's built-in dependency injection infrastructure. This decision aligns with the goal of simplifying the codebase and reducing
+external dependencies.
 
 ## Consequences
 
 **Positive outcomes:**
+
 - **Simplified Codebase**: Removing Autofac results in a cleaner, more maintainable codebase that adheres to .NET standards.
-- **Reduced Complexity**: The transition eliminates the need for additional files and configurations specific to Autofac, making the project easier to understand for new contributors.
-- **Standardization**: Adopting .NET's built-in DI promotes consistency with other .NET projects, making it easier for developers familiar with the framework to contribute effectively.
+- **Reduced Complexity**: The transition eliminates the need for additional files and configurations specific to Autofac, making the project
+  easier to understand for new contributors.
+- **Standardization**: Adopting .NET's built-in DI promotes consistency with other .NET projects, making it easier for developers familiar
+  with the framework to contribute effectively.
 
 **Negative outcomes:**
+
 - Loss of some advanced Autofac features (though not needed for this project)
 - Migration effort required for existing implementations
 
 **Follow-up tasks:**
+
 - Remove Autofac dependencies from project files
 - Update service registration code to use .NET DI patterns
 - Update documentation to reflect the change
@@ -44,5 +55,7 @@ Based on community feedback and a review of our project's requirements, we have 
 
 ## References
 
-- [Issue #649: Why is this repo using Autofac instead of .NET's own DI infrastructure?](https://github.com/ardalis/CleanArchitecture/issues/649) - Discussion that led to this decision.
-- [Getting Started with Architecture Decision Records](https://ardalis.com/getting-started-with-architecture-decision-records/) - Resource on ADR best practices.
+- [Issue #649: Why is this repo using Autofac instead of .NET's own DI infrastructure?](https://github.com/ardalis/CleanArchitecture/issues/649) -
+  Discussion that led to this decision.
+- [Getting Started with Architecture Decision Records](https://ardalis.com/getting-started-with-architecture-decision-records/) - Resource
+  on ADR best practices.


### PR DESCRIPTION
## Summary
- run Prettier on docs
- keep ADR markdown consistent with project style

## Testing
- `npx prettier --check --ignore-path .prettierignore "**/*.{md,json}"`

------
https://chatgpt.com/codex/tasks/task_e_6874dce88204832d84801a4995749129