### PR TITLE
Add autoformat script

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
     rev: v3.7.0
     hooks:
       - id: shfmt
-        args: ["-i", "2", "-d"]
+        args: ["-i", "2", "-w"]
   - repo: https://github.com/koalaman/shellcheck
     rev: v0.9.0
     hooks:
@@ -26,3 +26,8 @@ repos:
         language: system
         pass_filenames: false
         files: "\\.md$"
+      - id: autoformat
+        name: autoformat staged files
+        entry: ./scripts/autoformat.sh
+        language: script
+        pass_filenames: false

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -165,6 +165,7 @@ The `/scripts` folder contains tooling for environment setup and enforcement of 
 - Run `dotnet format` to auto-format C# code.
 - Run `shfmt -w` to format shell scripts.
 - Run `prettier --write .` for Markdown, JSON, and web assets (if applicable).
+- After changes, run `./scripts/autoformat.sh` to apply all formatting fixes.
 
 ### 5.3. Linting
 - `commitlint`: Enforces commit message conventions.
@@ -183,6 +184,7 @@ The `/scripts` folder contains tooling for environment setup and enforcement of 
 ### 5.6. CI/CD
 - Pre-commit and CI pipelines enforce all formatting, linting, and architectural rules.
 - See `.github/workflows/ci.yml` for full configuration details.
+- CI verifies formatting via `./scripts/format.sh` (also run by `selfcheck.sh`).
 
 ### 5.7. Automation
 All quality gates are enforced by:
@@ -343,7 +345,7 @@ This repository follows [Ardalis Clean Architecture](https://github.com/ardalis/
 ./scripts/selfcheck.sh
 
 # Format code
-./scripts/format.sh
+./scripts/autoformat.sh
 
 # Run architecture tests
 ./scripts/archtest.sh

--- a/scripts/autoformat.sh
+++ b/scripts/autoformat.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+# Apply .NET formatting fixes
+ dotnet format WebDownloadr.sln
+
+# Format shell scripts in-place
+shfmt -i 2 -w $(git ls-files '*.sh')
+
+# Format Markdown, JSON, and YAML files using Prettier
+npx --yes prettier --write --ignore-path .prettierignore "**/*.{md,json,ya?ml}"


### PR DESCRIPTION
## Summary
- introduce `scripts/autoformat.sh` for dotnet, shfmt and prettier fixes
- call the script from pre-commit
- document usage of new script in AGENTS.md

## Testing
- `./scripts/selfcheck.sh --skip-test --skip-build --skip-arch --skip-docs --skip-commitlint`

------
https://chatgpt.com/codex/tasks/task_e_6877a80f3f68832d98989689e2c44695