### PR TITLE
ci: run architecture tests within main job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,8 @@ jobs:
             --verbosity normal \
             --collect:"XPlat Code Coverage" \
             --results-directory ./coverage
+      - name: Run architecture tests
+        run: ./scripts/archtest.sh
       - name: Upload coverage reports
         uses: codecov/codecov-action@v3
         with:
@@ -61,14 +63,3 @@ jobs:
       - uses: actions/setup-node@v4
         with: { cache: npm }
       - run: npm ci --omit=optional
-
-  architecture-tests:
-    needs: check-formatting
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-dotnet@v4
-        with: { global-json-file: global.json }
-      - run: dotnet restore WebDownloadr.sln
-      - name: Run architecture tests
-        run: ./scripts/archtest.sh


### PR DESCRIPTION
## Summary
- remove separate architecture-tests job
- run architecture tests from build-and-test job
- confirm workflow syntax via `act`

## Testing
- `./scripts/selfcheck.sh`
- `act --list`


------
https://chatgpt.com/codex/tasks/task_e_6877aeaca738832d9653f1bd6c81ab22