### PR TITLE
feat: enhance page downloader

### DIFF
--- a/docs/architecture-decisions/0003-web-pages-functionality.md
+++ b/docs/architecture-decisions/0003-web-pages-functionality.md
@@ -39,7 +39,8 @@ download without tight coupling.
 
 **Follow-up tasks:**
 
-All initial web page features, validation and event handling have been implemented; no outstanding work remains.
+Initial web page features, validation and event handling have been implemented.
+Future enhancements may include allowing custom HTTP headers (e.g., a User-Agent) when downloading pages.
 
 ## Alternatives Considered
 

--- a/docs/architecture-decisions/0003-web-pages-functionality.md
+++ b/docs/architecture-decisions/0003-web-pages-functionality.md
@@ -39,8 +39,8 @@ download without tight coupling.
 
 **Follow-up tasks:**
 
-Initial web page features, validation and event handling have been implemented.
-Future enhancements may include allowing custom HTTP headers (e.g., a User-Agent) when downloading pages.
+Initial web page features, validation and event handling have been implemented. Future enhancements may include allowing custom HTTP headers
+(e.g., a User-Agent) when downloading pages.
 
 ## Alternatives Considered
 

--- a/src/WebDownloadr.Core/Interfaces/IWebPageDownloader.cs
+++ b/src/WebDownloadr.Core/Interfaces/IWebPageDownloader.cs
@@ -9,9 +9,10 @@ public interface IWebPageDownloader
   /// <summary>
   /// Downloads a collection of URLs and writes each file to <paramref name="outputDir"/>.
   /// </summary>
-  /// <param name="urls">The target URLs.</param>
+  /// <param name="pages">Pairs of page identifiers and URLs.</param>
   /// <param name="outputDir">Directory where downloaded pages are saved.</param>
   /// <param name="cancellationToken">Token used to cancel the operation.</param>
-  Task<Result> DownloadWebPagesAsync(IEnumerable<string> urls, string outputDir,
+  Task<Result> DownloadWebPagesAsync(IEnumerable<(Guid Id, string Url)> pages,
+    string outputDir,
     CancellationToken cancellationToken);
 }

--- a/src/WebDownloadr.Infrastructure/InfrastructureServiceExtensions.cs
+++ b/src/WebDownloadr.Infrastructure/InfrastructureServiceExtensions.cs
@@ -28,6 +28,8 @@ public static class InfrastructureServiceExtensions
       .AddScoped<IWebPageDownloader, SimpleWebPageDownloader>()
       .AddScoped<IDownloadWebPageService, DownloadWebPageService>();
 
+    services.Configure<SimpleWebPageDownloaderOptions>(config.GetSection("WebPageDownloader"));
+
     logger.LogInformation("{Project} services registered", "Infrastructure");
 
     return services;

--- a/src/WebDownloadr.Infrastructure/README.md
+++ b/src/WebDownloadr.Infrastructure/README.md
@@ -3,5 +3,5 @@
 This project provides implementations for external dependencies used by the application such as HTTP clients or data stores. These services
 implement interfaces defined in the Core or UseCases projects and are wired up at runtime by the Web project.
 
-The `Web` folder contains `SimpleWebPageDownloader`, a configurable HTTP downloader used by `DownloadWebPageService`.
-It streams responses directly to disk, limits concurrent downloads and names each file using the `WebPageId`.
+The `Web` folder contains `SimpleWebPageDownloader`, a configurable HTTP downloader used by `DownloadWebPageService`. It streams responses
+directly to disk, limits concurrent downloads and names each file using the `WebPageId`.

--- a/src/WebDownloadr.Infrastructure/README.md
+++ b/src/WebDownloadr.Infrastructure/README.md
@@ -3,4 +3,5 @@
 This project provides implementations for external dependencies used by the application such as HTTP clients or data stores. These services
 implement interfaces defined in the Core or UseCases projects and are wired up at runtime by the Web project.
 
-The `Web` folder contains a simple HTTP downloader (`SimpleWebPageDownloader`) used by `DownloadWebPageService`.
+The `Web` folder contains `SimpleWebPageDownloader`, a configurable HTTP downloader used by `DownloadWebPageService`.
+It streams responses directly to disk, limits concurrent downloads and names each file using the `WebPageId`.

--- a/src/WebDownloadr.Infrastructure/Web/SimpleWebPageDownloader.cs
+++ b/src/WebDownloadr.Infrastructure/Web/SimpleWebPageDownloader.cs
@@ -9,31 +9,52 @@ using Polly;
 /// Basic <see cref="IWebPageDownloader"/> implementation that retrieves pages
 /// via HTTP and saves them to disk.
 /// </summary>
-public class SimpleWebPageDownloader(ILogger<SimpleWebPageDownloader> logger) : IWebPageDownloader
+public class SimpleWebPageDownloader(ILogger<SimpleWebPageDownloader> logger,
+    IOptions<SimpleWebPageDownloaderOptions> options) : IWebPageDownloader
 {
-  private static IAsyncPolicy GetFlurlRetryPolicy() =>
+  private readonly ILogger<SimpleWebPageDownloader> _logger = logger;
+  private readonly SimpleWebPageDownloaderOptions _options = options.Value;
+
+  private IAsyncPolicy GetFlurlRetryPolicy() =>
     Policy
       .Handle<FlurlHttpException>()
       .Or<FlurlHttpTimeoutException>()
       .WaitAndRetryAsync(
-        retryCount: 3,
+        retryCount: _options.RetryCount,
         sleepDurationProvider: attempt => TimeSpan.FromSeconds(Math.Pow(2, attempt))
       );
 
   /// <inheritdoc />
-  public async Task<Result> DownloadWebPagesAsync(IEnumerable<string> urls, string outputDir,
+  public async Task<Result> DownloadWebPagesAsync(
+    IEnumerable<(Guid Id, string Url)> pages,
+    string outputDir,
     CancellationToken cancellationToken)
   {
     Directory.CreateDirectory(outputDir);
     var policy = GetFlurlRetryPolicy();
-    var tasks = new List<Task>();
-    foreach (var url in urls)
-    {
-      tasks.Add(DownloadSingleWebPageAsync(url, outputDir, policy, cancellationToken));
-    }
+
+    using var semaphore = new SemaphoreSlim(_options.MaxConcurrentDownloads);
+    var tasks = pages.Select(page => DownloadWithSemaphore(page, outputDir, policy, semaphore, cancellationToken));
     await Task.WhenAll(tasks);
 
     return Result.Success();
+  }
+
+  private async Task DownloadWithSemaphore((Guid Id, string Url) page,
+    string outputDir,
+    IAsyncPolicy policy,
+    SemaphoreSlim semaphore,
+    CancellationToken cancellationToken)
+  {
+    await semaphore.WaitAsync(cancellationToken);
+    try
+    {
+      await DownloadSingleWebPageAsync(page.Id, page.Url, outputDir, policy, cancellationToken);
+    }
+    finally
+    {
+      semaphore.Release();
+    }
   }
 
   /// <summary>
@@ -43,31 +64,19 @@ public class SimpleWebPageDownloader(ILogger<SimpleWebPageDownloader> logger) : 
   /// <param name="outputDir">Output directory.</param>
   /// <param name="policy">Polly retry policy.</param>
   /// <param name="cancellationToken">Token used to cancel the operation.</param>
-  private async Task<Result> DownloadSingleWebPageAsync(string url, string outputDir, IAsyncPolicy policy,
+  private async Task<Result> DownloadSingleWebPageAsync(Guid id, string url, string outputDir,
+    IAsyncPolicy policy,
     CancellationToken cancellationToken)
   {
-    logger.LogInformation("Downloading {Url} and saving to directory {OutputDir}", url, outputDir);
+    _logger.LogInformation("Downloading {Url} and saving to directory {OutputDir}", url, outputDir);
 
-    // Use Flurl to build the request, and Polly to handle retries.
-    var response = await policy.ExecuteAsync(ct =>
-      url.WithTimeout(20).GetAsync(cancellationToken: ct), cancellationToken);
+    var stream = await policy.ExecuteAsync(ct =>
+      url.WithTimeout(_options.TimeoutSeconds).GetStreamAsync(cancellationToken: ct), cancellationToken);
 
-    var content = await response.GetStringAsync();
-
-    var fileName = Path.Combine(outputDir, GetSafeFilename(url) + ".html");
-    await File.WriteAllTextAsync(fileName, content, cancellationToken);
+    var fileName = Path.Combine(outputDir, $"{id}.html");
+    await using var file = File.Create(fileName);
+    await stream.CopyToAsync(file, cancellationToken);
 
     return Result.Success();
-  }
-
-  /// <summary>
-  /// Converts a URL into a safe file name.
-  /// </summary>
-  private string GetSafeFilename(string url)
-  {
-    // Basic sanitization; we may want to use a better method
-    foreach (var c in Path.GetInvalidFileNameChars())
-      url = url.Replace(c, '_');
-    return url.Replace("https://", "").Replace("http://", "").Replace("/", "_");
   }
 }

--- a/src/WebDownloadr.Infrastructure/Web/SimpleWebPageDownloaderOptions.cs
+++ b/src/WebDownloadr.Infrastructure/Web/SimpleWebPageDownloaderOptions.cs
@@ -1,8 +1,8 @@
-namespace WebDownloadr.Infrastructure.Web;
+﻿namespace WebDownloadr.Infrastructure.Web;
 
 public class SimpleWebPageDownloaderOptions
 {
-    public int RetryCount { get; set; } = 3;
-    public int TimeoutSeconds { get; set; } = 20;
-    public int MaxConcurrentDownloads { get; set; } = 4;
+  public int RetryCount { get; set; } = 3;
+  public int TimeoutSeconds { get; set; } = 20;
+  public int MaxConcurrentDownloads { get; set; } = 4;
 }

--- a/src/WebDownloadr.Infrastructure/Web/SimpleWebPageDownloaderOptions.cs
+++ b/src/WebDownloadr.Infrastructure/Web/SimpleWebPageDownloaderOptions.cs
@@ -1,0 +1,8 @@
+namespace WebDownloadr.Infrastructure.Web;
+
+public class SimpleWebPageDownloaderOptions
+{
+    public int RetryCount { get; set; } = 3;
+    public int TimeoutSeconds { get; set; } = 20;
+    public int MaxConcurrentDownloads { get; set; } = 4;
+}

--- a/src/WebDownloadr.Web/Configurations/OptionConfigs.cs
+++ b/src/WebDownloadr.Web/Configurations/OptionConfigs.cs
@@ -1,5 +1,6 @@
 ﻿using Ardalis.ListStartupServices;
 using WebDownloadr.Infrastructure.Email;
+using WebDownloadr.Infrastructure.Web;
 
 namespace WebDownloadr.Web.Configurations;
 
@@ -11,6 +12,7 @@ public static class OptionConfigs
                                                     WebApplicationBuilder builder)
   {
     services.Configure<MailserverConfiguration>(configuration.GetSection("Mailserver"))
+    .Configure<SimpleWebPageDownloaderOptions>(configuration.GetSection("WebPageDownloader"))
     // Configure Web Behavior
     .Configure<CookiePolicyOptions>(options =>
     {

--- a/src/WebDownloadr.Web/appsettings.json
+++ b/src/WebDownloadr.Web/appsettings.json
@@ -32,5 +32,10 @@
   "Mailserver": {
     "Server": "localhost",
     "Port": 25
+  },
+  "WebPageDownloader": {
+    "RetryCount": 3,
+    "TimeoutSeconds": 20,
+    "MaxConcurrentDownloads": 4
   }
 }

--- a/tests/WebDownloadr.UnitTests/Core/Services/DownloadWebPageService_CancelDownloadAsync.cs
+++ b/tests/WebDownloadr.UnitTests/Core/Services/DownloadWebPageService_CancelDownloadAsync.cs
@@ -53,7 +53,7 @@ public class DownloadWebPageService_CancelDownloadAsync
   {
     public TaskCompletionSource Started { get; } = new();
 
-    public async Task<Result> DownloadWebPagesAsync(IEnumerable<string> urls, string outputDir, CancellationToken cancellationToken)
+    public async Task<Result> DownloadWebPagesAsync(IEnumerable<(Guid Id, string Url)> pages, string outputDir, CancellationToken cancellationToken)
     {
       Directory.CreateDirectory(outputDir);
       Started.SetResult();

--- a/tests/WebDownloadr.UnitTests/Core/Services/DownloadWebPageService_DownloadWebPageAsync.cs
+++ b/tests/WebDownloadr.UnitTests/Core/Services/DownloadWebPageService_DownloadWebPageAsync.cs
@@ -104,23 +104,13 @@ public class DownloadWebPageService_DownloadWebPageAsync
     public const string Content = "<html>content</html>";
     private readonly bool _succeed = succeed;
 
-    public Task<Result> DownloadWebPagesAsync(IEnumerable<string> urls, string outputDir, CancellationToken cancellationToken)
+    public Task<Result> DownloadWebPagesAsync(IEnumerable<(Guid Id, string Url)> pages, string outputDir, CancellationToken cancellationToken)
     {
       Directory.CreateDirectory(outputDir);
-      var url = urls.First();
-      var fileName = Path.Combine(outputDir, GetSafeFilename(url) + ".html");
+      var page = pages.First();
+      var fileName = Path.Combine(outputDir, $"{page.Id}.html");
       File.WriteAllText(fileName, Content);
       return Task.FromResult(_succeed ? Result.Success() : Result.Error("fail"));
-    }
-
-    private static string GetSafeFilename(string url)
-    {
-      foreach (var c in Path.GetInvalidFileNameChars())
-      {
-        url = url.Replace(c, '_');
-      }
-
-      return url.Replace("https://", "").Replace("http://", "").Replace("/", "_");
     }
   }
 }

--- a/tests/WebDownloadr.UnitTests/Infrastructure/Web/SimpleWebPageDownloader_DownloadWebPagesAsync.cs
+++ b/tests/WebDownloadr.UnitTests/Infrastructure/Web/SimpleWebPageDownloader_DownloadWebPagesAsync.cs
@@ -13,15 +13,18 @@ public class SimpleWebPageDownloader_DownloadWebPagesAsync
     httpTest.RespondWith("<html>content</html>");
 
     var logger = Substitute.For<ILogger<SimpleWebPageDownloader>>();
-    var downloader = new SimpleWebPageDownloader(logger);
+    var options = Options.Create(new SimpleWebPageDownloaderOptions());
+    var downloader = new SimpleWebPageDownloader(logger, options);
     var outputDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
     try
     {
-      await downloader.DownloadWebPagesAsync(new[] { "https://example.com" }, outputDir, CancellationToken.None);
+      var id = Guid.NewGuid();
+      await downloader.DownloadWebPagesAsync(new[] { (id, "https://example.com") }, outputDir, CancellationToken.None);
 
       var files = Directory.GetFiles(outputDir);
       files.Length.ShouldBe(1);
       var file = files[0];
+      file.EndsWith($"{id}.html").ShouldBeTrue();
       (await File.ReadAllTextAsync(file)).ShouldBe("<html>content</html>");
     }
     finally
@@ -39,11 +42,12 @@ public class SimpleWebPageDownloader_DownloadWebPagesAsync
     httpTest.RespondWith("success");
 
     var logger = Substitute.For<ILogger<SimpleWebPageDownloader>>();
-    var downloader = new SimpleWebPageDownloader(logger);
+    var options = Options.Create(new SimpleWebPageDownloaderOptions());
+    var downloader = new SimpleWebPageDownloader(logger, options);
     var outputDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
     try
     {
-      await downloader.DownloadWebPagesAsync(new[] { "https://example.com" }, outputDir, CancellationToken.None);
+      await downloader.DownloadWebPagesAsync(new[] { (Guid.NewGuid(), "https://example.com") }, outputDir, CancellationToken.None);
 
       httpTest.CallLog.Count.ShouldBe(2);
     }

--- a/tests/WebDownloadr.UnitTests/Infrastructure/Web/SimpleWebPageDownloader_DownloadWebPagesAsync.cs
+++ b/tests/WebDownloadr.UnitTests/Infrastructure/Web/SimpleWebPageDownloader_DownloadWebPagesAsync.cs
@@ -1,5 +1,6 @@
 ﻿using System.Threading;
 using Flurl.Http.Testing;
+using Microsoft.Extensions.Options;
 using WebDownloadr.Infrastructure.Web;
 
 namespace WebDownloadr.UnitTests.Infrastructure.Web;


### PR DESCRIPTION
## Summary
- add configurable `SimpleWebPageDownloaderOptions`
- stream HTTP responses directly to disk and limit concurrency
- name downloaded pages by WebPageId
- expose downloader options in web `appsettings.json`
- update docs and ADR
- update unit tests for new behaviour

## Testing
- `./scripts/autoformat.sh` *(fails: dotnet not found)*
- `./scripts/selfcheck.sh` *(fails: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_e_6877c045a86c832da60516f9a2f5d123