### PR TITLE
Remove formatting checks from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
     { branches: [main] }
 
 jobs:
-  check-formatting:
+  validate:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -18,17 +18,11 @@ jobs:
           key: ${{ runner.os }}-nuget-${{ hashFiles('**/packages.lock.json') }}
           restore-keys: ${{ runner.os }}-nuget-
       - run: dotnet restore WebDownloadr.sln
-      - name: Check .NET formatting
-        run: dotnet format WebDownloadr.sln --verify-no-changes --verbosity diagnostic
-      - name: MarkdownLint docs
-        run: npx --yes markdownlint-cli2 "**/*.md" "#node_modules"
-      - name: Prettier check
-        run: npx --yes prettier --check --ignore-path .prettierignore "**/*.{md,json}"
       - name: Validate ADRs
         run: ./scripts/validate-adrs.sh
 
   build-and-test:
-    needs: check-formatting
+    needs: validate
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -182,9 +182,9 @@ The `/scripts` folder contains tooling for environment setup and enforcement of 
 - Minimum coverage thresholds are enforced per project.
 
 ### 5.6. CI/CD
-- Pre-commit and CI pipelines enforce all formatting, linting, and architectural rules.
+- Pre-commit hooks enforce formatting. CI focuses on linting, tests, and architecture checks.
 - See `.github/workflows/ci.yml` for full configuration details.
-- CI verifies formatting via `./scripts/format.sh` (also run by `selfcheck.sh`).
+- Run `./scripts/format.sh` locally (or via pre-commit) to check formatting when needed.
 
 ### 5.7. Automation
 All quality gates are enforced by:

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ git commit -m "style: normalize line endings to match .editorconfig"
 
 The repository's `.gitattributes` enforces LF for text files and marks common binaries.
 
-After this commit, `./scripts/format.sh` (or `dotnet format`) runs in CI and must report no changes.
+After this commit, run `./scripts/format.sh` (or `dotnet format`) locally to ensure no style fixes are needed.
 
 Prettier and `markdownlint-cli2` enforce documentation style. They run automatically via pre-commit but you can verify manually with
 `npx prettier --check .` and `npx markdownlint-cli2`.


### PR DESCRIPTION
## Summary
- stop running dotnet format, prettier, and markdownlint in CI
- note that CI focuses on linting/tests in `AGENTS.md`
- update docs to suggest running `format.sh` locally

## Testing
- `./scripts/selfcheck.sh --skip-commitlint`

------
https://chatgpt.com/codex/tasks/task_e_6877d4c60c50832dafb1bd041bd1dc50