### PR TITLE
feat(usecases): support cancellation token on list queries

### DIFF
--- a/src/WebDownloadr.Infrastructure/Data/Queries/FakeListContributorsQueryService.cs
+++ b/src/WebDownloadr.Infrastructure/Data/Queries/FakeListContributorsQueryService.cs
@@ -5,7 +5,7 @@ namespace WebDownloadr.Infrastructure.Data.Queries;
 
 public class FakeListContributorsQueryService : IListContributorsQueryService
 {
-  public Task<IEnumerable<ContributorDTO>> ListAsync()
+  public Task<IEnumerable<ContributorDTO>> ListAsync(CancellationToken ct)
   {
     IEnumerable<ContributorDTO> result =
         [new ContributorDTO(1, "Fake Contributor 1", ""),

--- a/src/WebDownloadr.Infrastructure/Data/Queries/ListContributorsQueryService.cs
+++ b/src/WebDownloadr.Infrastructure/Data/Queries/ListContributorsQueryService.cs
@@ -8,12 +8,12 @@ public class ListContributorsQueryService(AppDbContext _db) : IListContributorsQ
   // You can use EF, Dapper, SqlClient, etc. for queries -
   // this is just an example
 
-  public async Task<IEnumerable<ContributorDTO>> ListAsync()
+  public async Task<IEnumerable<ContributorDTO>> ListAsync(CancellationToken ct)
   {
     // NOTE: This will fail if testing with EF InMemory provider!
     var result = await _db.Database.SqlQuery<ContributorDTO>(
       $"SELECT Id, Name, PhoneNumber_Number AS PhoneNumber FROM Contributors") // don't fetch other big columns
-      .ToListAsync();
+      .ToListAsync(ct);
 
     return result;
   }

--- a/src/WebDownloadr.Infrastructure/Data/Queries/ListWebPagesQueryService.cs
+++ b/src/WebDownloadr.Infrastructure/Data/Queries/ListWebPagesQueryService.cs
@@ -6,11 +6,11 @@ namespace WebDownloadr.Infrastructure.Data.Queries;
 
 public class ListWebPagesQueryService(AppDbContext db) : IListWebPagesQueryService
 {
-  public async Task<IEnumerable<WebPageDTO>> ListAsync()
+  public async Task<IEnumerable<WebPageDTO>> ListAsync(CancellationToken ct)
   {
     var result = await db.Database.SqlQuery<WebPageDTO>(
       $"SELECT Id, Url, Status FROM WebPages")
-      .ToListAsync();
+      .ToListAsync(ct);
 
     return result;
   }

--- a/src/WebDownloadr.UseCases/Contributors/List/IListContributorsQueryService.cs
+++ b/src/WebDownloadr.UseCases/Contributors/List/IListContributorsQueryService.cs
@@ -6,5 +6,5 @@
 /// </summary>
 public interface IListContributorsQueryService
 {
-  Task<IEnumerable<ContributorDTO>> ListAsync();
+  Task<IEnumerable<ContributorDTO>> ListAsync(CancellationToken ct = default);
 }

--- a/src/WebDownloadr.UseCases/Contributors/List/ListContributorsHandler.cs
+++ b/src/WebDownloadr.UseCases/Contributors/List/ListContributorsHandler.cs
@@ -14,7 +14,7 @@ public class ListContributorsHandler(IListContributorsQueryService _query)
   /// <returns>Contributors returned by the query service.</returns>
   public async Task<Result<IEnumerable<ContributorDTO>>> Handle(ListContributorsQuery request, CancellationToken cancellationToken)
   {
-    var result = await _query.ListAsync();
+    var result = await _query.ListAsync(cancellationToken);
 
     return Result.Success(result);
   }

--- a/src/WebDownloadr.UseCases/WebPages/List/IListWebPagesQueryService.cs
+++ b/src/WebDownloadr.UseCases/WebPages/List/IListWebPagesQueryService.cs
@@ -5,5 +5,5 @@
 /// </summary>
 public interface IListWebPagesQueryService
 {
-  Task<IEnumerable<WebPageDTO>> ListAsync();
+  Task<IEnumerable<WebPageDTO>> ListAsync(CancellationToken ct = default);
 }

--- a/src/WebDownloadr.UseCases/WebPages/List/ListWebPagesHandler.cs
+++ b/src/WebDownloadr.UseCases/WebPages/List/ListWebPagesHandler.cs
@@ -14,7 +14,7 @@ public class ListWebPagesHandler(IListWebPagesQueryService query)
   /// <returns>Collection of pages wrapped in a successful result.</returns>
   public async Task<Result<IEnumerable<WebPageDTO>>> Handle(ListWebPagesQuery request, CancellationToken cancellationToken)
   {
-    var result = await query.ListAsync();
+    var result = await query.ListAsync(cancellationToken);
     return Result.Success(result);
   }
 }

--- a/tests/WebDownloadr.IntegrationTests/Data/WebPages/ListWebPagesQueryService.cs
+++ b/tests/WebDownloadr.IntegrationTests/Data/WebPages/ListWebPagesQueryService.cs
@@ -30,7 +30,7 @@ public class ListWebPagesQueryServiceTests
 
     var service = new ListWebPagesQueryService(context);
 
-    var result = (await service.ListAsync()).ToList();
+    var result = (await service.ListAsync(CancellationToken.None)).ToList();
 
     result.Count.ShouldBe(2);
     result.Any(p => p.Url == "https://one.com").ShouldBeTrue();


### PR DESCRIPTION
## Summary
- add optional CancellationToken parameter to IListWebPagesQueryService and IListContributorsQueryService
- update query service implementations to accept the token
- pass token through handlers
- fix integration test to call new ListAsync overload

## Testing
- `dotnet format --verify-no-changes`
- `dotnet build src/WebDownloadr.UseCases -c Release`
- `dotnet test tests/WebDownloadr.UnitTests`
- `./scripts/selfcheck.sh --skip-arch`

------
https://chatgpt.com/codex/tasks/task_e_688386133b18832db861fc62777a2062