### PR TITLE
fix: remove unused using

### DIFF
--- a/src/WebDownloadr.UseCases/WebPages/Delete/DeleteWebPageCommand.cs
+++ b/src/WebDownloadr.UseCases/WebPages/Delete/DeleteWebPageCommand.cs
@@ -1,6 +1,4 @@
-﻿using System.Windows.Input;
-
-namespace WebDownloadr.UseCases.WebPages.Delete;
+﻿namespace WebDownloadr.UseCases.WebPages.Delete;
 
 /// <summary>
 /// Command to delete a tracked web page.


### PR DESCRIPTION
## Summary
- remove the leftover `System.Windows.Input` directive from DeleteWebPageCommand

## Testing
- `./scripts/selfcheck.sh --skip-test`
- `dotnet format --verify-no-changes`


------
https://chatgpt.com/codex/tasks/task_e_68838619b20c832d8a1a293fdaf8ba29