### PR TITLE
test: add contributor endpoint validations

### DIFF
--- a/src/WebDownloadr.Web/Contributors/Create.cs
+++ b/src/WebDownloadr.Web/Contributors/Create.cs
@@ -36,6 +36,5 @@ public class Create(IMediator _mediator)
       Response = new CreateContributorResponse(result.Value, request.Name!);
       return;
     }
-    // TODO: Handle other cases as necessary
   }
 }

--- a/src/WebDownloadr.Web/Contributors/Delete.cs
+++ b/src/WebDownloadr.Web/Contributors/Delete.cs
@@ -35,6 +35,5 @@ public class Delete(IMediator _mediator)
     {
       await SendNoContentAsync(cancellationToken);
     }
-    // TODO: Handle other issues as needed
   }
 }

--- a/tests/WebDownloadr.FunctionalTests/ApiEndpoints/ContributorCreate.cs
+++ b/tests/WebDownloadr.FunctionalTests/ApiEndpoints/ContributorCreate.cs
@@ -1,0 +1,27 @@
+﻿using Ardalis.HttpClientTestExtensions;
+using WebDownloadr.Web.Contributors;
+
+namespace WebDownloadr.FunctionalTests.ApiEndpoints;
+
+[Collection("Sequential")]
+public class ContributorCreate(CustomWebApplicationFactory<Program> factory) : IClassFixture<CustomWebApplicationFactory<Program>>
+{
+  private readonly HttpClient _client = factory.CreateClient();
+
+  [Fact]
+  public async Task CanCreateContributor()
+  {
+    var request = new CreateContributorRequest { Name = "Test Contributor" };
+    var create = await _client.PostAndDeserializeAsync<CreateContributorResponse>(CreateContributorRequest.Route, StringContentHelpers.FromModelAsJson(request));
+
+    create.Name.ShouldBe("Test Contributor");
+    create.Id.ShouldBeGreaterThan(0);
+  }
+
+  [Fact]
+  public async Task ReturnsBadRequestGivenInvalidName()
+  {
+    var request = new CreateContributorRequest { Name = string.Empty };
+    await _client.PostAndEnsureBadRequestAsync(CreateContributorRequest.Route, StringContentHelpers.FromModelAsJson(request));
+  }
+}

--- a/tests/WebDownloadr.FunctionalTests/ApiEndpoints/ContributorDelete.cs
+++ b/tests/WebDownloadr.FunctionalTests/ApiEndpoints/ContributorDelete.cs
@@ -21,4 +21,11 @@ public class ContributorDelete(CustomWebApplicationFactory<Program> factory) : I
     string route = DeleteContributorRequest.BuildRoute(1000);
     _ = await _client.DeleteAndEnsureNotFoundAsync(route);
   }
+
+  [Fact]
+  public async Task ReturnsBadRequestGivenIdZero()
+  {
+    string route = DeleteContributorRequest.BuildRoute(0);
+    _ = await _client.DeleteAndEnsureBadRequestAsync(route);
+  }
 }


### PR DESCRIPTION
## Summary
- remove obsolete TODO comments in Contributor endpoints
- add functional tests covering create and delete validation scenarios

## Testing
- `dotnet format --no-restore`
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_6883861dcbe4832da93a72f3f9d5c4f2