### PR TITLE
refactor: use EF Core for list query services

### DIFF
--- a/src/WebDownloadr.Infrastructure/Data/Queries/ListContributorsQueryService.cs
+++ b/src/WebDownloadr.Infrastructure/Data/Queries/ListContributorsQueryService.cs
@@ -1,4 +1,5 @@
-﻿using WebDownloadr.UseCases.Contributors;
+﻿using Microsoft.EntityFrameworkCore;
+using WebDownloadr.UseCases.Contributors;
 using WebDownloadr.UseCases.Contributors.List;
 
 namespace WebDownloadr.Infrastructure.Data.Queries;
@@ -10,11 +11,9 @@ public class ListContributorsQueryService(AppDbContext _db) : IListContributorsQ
 
   public async Task<IEnumerable<ContributorDTO>> ListAsync()
   {
-    // NOTE: This will fail if testing with EF InMemory provider!
-    var result = await _db.Database.SqlQuery<ContributorDTO>(
-      $"SELECT Id, Name, PhoneNumber_Number AS PhoneNumber FROM Contributors") // don't fetch other big columns
+    return await _db.Contributors
+      .AsNoTracking()
+      .Select(c => new ContributorDTO(c.Id, c.Name, (object?)c.PhoneNumber != null ? c.PhoneNumber.Number : null))
       .ToListAsync();
-
-    return result;
   }
 }

--- a/src/WebDownloadr.Infrastructure/Data/Queries/ListWebPagesQueryService.cs
+++ b/src/WebDownloadr.Infrastructure/Data/Queries/ListWebPagesQueryService.cs
@@ -1,4 +1,5 @@
-﻿using WebDownloadr.Infrastructure.Data;
+﻿using Microsoft.EntityFrameworkCore;
+using WebDownloadr.Infrastructure.Data;
 using WebDownloadr.UseCases.WebPages;
 using WebDownloadr.UseCases.WebPages.List;
 
@@ -8,10 +9,9 @@ public class ListWebPagesQueryService(AppDbContext db) : IListWebPagesQueryServi
 {
   public async Task<IEnumerable<WebPageDTO>> ListAsync()
   {
-    var result = await db.Database.SqlQuery<WebPageDTO>(
-      $"SELECT Id, Url, Status FROM WebPages")
+    return await db.WebPages
+      .AsNoTracking()
+      .Select(p => new WebPageDTO(p.Id.Value, p.Url.Value, p.Status.Name))
       .ToListAsync();
-
-    return result;
   }
 }

--- a/tests/WebDownloadr.IntegrationTests/Data/Contributors/ListContributorsQueryService.cs
+++ b/tests/WebDownloadr.IntegrationTests/Data/Contributors/ListContributorsQueryService.cs
@@ -1,0 +1,39 @@
+﻿using Microsoft.Data.Sqlite;
+using WebDownloadr.Core.ContributorAggregate;
+using WebDownloadr.Infrastructure.Data;
+using WebDownloadr.Infrastructure.Data.Queries;
+using WebDownloadr.UseCases.Contributors;
+
+namespace WebDownloadr.IntegrationTests.Data.Contributors;
+
+public class ListContributorsQueryServiceTests
+{
+  [Fact]
+  public async Task ReturnsAllContributors()
+  {
+    using var connection = new SqliteConnection("DataSource=:memory:");
+    connection.Open();
+
+    var options = new DbContextOptionsBuilder<AppDbContext>()
+      .UseSqlite(connection)
+      .Options;
+
+    var dispatcher = Substitute.For<IDomainEventDispatcher>();
+    using var context = new AppDbContext(options, dispatcher);
+    context.Database.EnsureCreated();
+
+    context.Contributors.AddRange([
+      new Contributor("One"),
+      new Contributor("Two")
+    ]);
+    await context.SaveChangesAsync();
+
+    var service = new ListContributorsQueryService(context);
+
+    var result = (await service.ListAsync()).ToList();
+
+    result.Count.ShouldBe(2);
+    result.Any(c => c.Name == "One").ShouldBeTrue();
+    result.Any(c => c.Name == "Two").ShouldBeTrue();
+  }
+}


### PR DESCRIPTION
## Summary
- use EF Core LINQ in `ListContributorsQueryService`
- use EF Core LINQ in `ListWebPagesQueryService`
- add integration test for `ListContributorsQueryService`

## Testing
- `./scripts/selfcheck.sh --skip-arch --skip-commitlint`

------
https://chatgpt.com/codex/tasks/task_e_6883862403f0832daaa676c29c6af46e