### PR TITLE
feat: add database seeder service

### DIFF
--- a/src/WebDownloadr.Infrastructure/Data/DatabaseSeeder.cs
+++ b/src/WebDownloadr.Infrastructure/Data/DatabaseSeeder.cs
@@ -1,0 +1,18 @@
+﻿namespace WebDownloadr.Infrastructure.Data;
+
+public sealed class DatabaseSeeder(AppDbContext context, ILogger<DatabaseSeeder> logger) : IDatabaseSeeder
+{
+  public async Task SeedAsync()
+  {
+    try
+    {
+      context.Database.EnsureCreated();
+      await SeedData.InitializeAsync(context);
+    }
+    catch (Exception ex)
+    {
+      logger.LogError(ex, "An error occurred seeding the DB. {exceptionMessage}", ex.Message);
+    }
+  }
+}
+

--- a/src/WebDownloadr.Infrastructure/Data/IDatabaseSeeder.cs
+++ b/src/WebDownloadr.Infrastructure/Data/IDatabaseSeeder.cs
@@ -1,0 +1,7 @@
+﻿namespace WebDownloadr.Infrastructure.Data;
+
+public interface IDatabaseSeeder
+{
+  Task SeedAsync();
+}
+

--- a/src/WebDownloadr.Infrastructure/InfrastructureServiceExtensions.cs
+++ b/src/WebDownloadr.Infrastructure/InfrastructureServiceExtensions.cs
@@ -26,7 +26,8 @@ public static class InfrastructureServiceExtensions
       .AddScoped<IListWebPagesQueryService, ListWebPagesQueryService>()
       .AddScoped<IDeleteContributorService, DeleteContributorService>()
       .AddScoped<IWebPageDownloader, SimpleWebPageDownloader>()
-      .AddScoped<IDownloadWebPageService, DownloadWebPageService>();
+      .AddScoped<IDownloadWebPageService, DownloadWebPageService>()
+      .AddScoped<IDatabaseSeeder, DatabaseSeeder>();
 
     services.Configure<SimpleWebPageDownloaderOptions>(config.GetSection("WebPageDownloader"));
 

--- a/src/WebDownloadr.Web/Configurations/MiddlewareConfig.cs
+++ b/src/WebDownloadr.Web/Configurations/MiddlewareConfig.cs
@@ -5,7 +5,7 @@ namespace WebDownloadr.Web.Configurations;
 
 public static class MiddlewareConfig
 {
-  public static async Task<IApplicationBuilder> UseAppMiddlewareAndSeedDatabase(this WebApplication app)
+  public static async Task<IApplicationBuilder> UseAppMiddlewareAndSeedDatabase(this WebApplication app, IDatabaseSeeder seeder)
   {
     if (app.Environment.IsDevelopment())
     {
@@ -23,27 +23,9 @@ public static class MiddlewareConfig
 
     app.UseHttpsRedirection(); // Note this will drop Authorization headers
 
-    await SeedDatabase(app);
+    await seeder.SeedAsync();
 
     return app;
   }
-
-  static async Task SeedDatabase(WebApplication app)
-  {
-    using var scope = app.Services.CreateScope();
-    var services = scope.ServiceProvider;
-
-    try
-    {
-      var context = services.GetRequiredService<AppDbContext>();
-      //          context.Database.Migrate();
-      context.Database.EnsureCreated();
-      await SeedData.InitializeAsync(context);
-    }
-    catch (Exception ex)
-    {
-      var logger = services.GetRequiredService<ILogger<Program>>();
-      logger.LogError(ex, "An error occurred seeding the DB. {exceptionMessage}", ex.Message);
-    }
-  }
 }
+

--- a/src/WebDownloadr.Web/Program.cs
+++ b/src/WebDownloadr.Web/Program.cs
@@ -1,4 +1,6 @@
-﻿using WebDownloadr.Web.Configurations;
+﻿using Microsoft.Extensions.DependencyInjection;
+using WebDownloadr.Infrastructure.Data;
+using WebDownloadr.Web.Configurations;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -27,9 +29,14 @@ builder.AddServiceDefaults();
 
 var app = builder.Build();
 
-await app.UseAppMiddlewareAndSeedDatabase();
+using (var scope = app.Services.CreateScope())
+{
+  var seeder = scope.ServiceProvider.GetRequiredService<IDatabaseSeeder>();
+  await app.UseAppMiddlewareAndSeedDatabase(seeder);
+}
 
 app.Run();
 
 // Make the implicit Program.cs class public, so integration tests can reference the correct assembly for host building
 public partial class Program { }
+

--- a/tests/WebDownloadr.IntegrationTests/Data/DatabaseSeeder.cs
+++ b/tests/WebDownloadr.IntegrationTests/Data/DatabaseSeeder.cs
@@ -1,0 +1,21 @@
+﻿using Microsoft.Extensions.Logging.Abstractions;
+using WebDownloadr.Infrastructure.Data;
+
+namespace WebDownloadr.IntegrationTests.Data;
+
+public class DatabaseSeederTests : BaseEfRepoTestFixture
+{
+  [Fact]
+  public async Task SeedsContributors()
+  {
+    var seeder = new DatabaseSeeder(_dbContext, NullLogger<DatabaseSeeder>.Instance);
+
+    await seeder.SeedAsync();
+
+    var contributor = await _dbContext.Contributors
+      .FirstOrDefaultAsync(c => c.Name == SeedData.Contributor1.Name);
+
+    contributor.ShouldNotBeNull();
+  }
+}
+


### PR DESCRIPTION
## Summary
- add `IDatabaseSeeder` abstraction and implementation
- invoke seeding through middleware using DI
- cover database seeder with integration test

## Testing
- `./scripts/selfcheck.sh`

------
https://chatgpt.com/codex/tasks/task_e_688fcf738fe0832da37f3adbb814b816